### PR TITLE
return 'None' if key doesn't exist

### DIFF
--- a/lib/autokey/scripting_Store.py
+++ b/lib/autokey/scripting_Store.py
@@ -17,7 +17,7 @@ class Store(dict):
         
         Usage: C{store.get_value(key)}
         """
-        return self[key]        
+        return self.get(key, None)        
         
     def remove_value(self, key):
         """
@@ -43,7 +43,7 @@ class Store(dict):
         
         Usage: C{store.get_global_value(key)}
         """
-        return self.GLOBALS[key]        
+        return self.GLOBALS.get(key, None)        
         
     def remove_global_value(self, key):
         """


### PR DESCRIPTION
Prevents KeyError if you try to **get_(global_)value** from a key that doesn't exist and also importantly allows existence checking.