### PR TITLE
Use XDG_RUNTIME_DIR and XDG_DATA_HOME for lock and log file

### DIFF
--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -19,8 +19,14 @@
 import os, dbus.service
 
 CONFIG_DIR = os.path.join(os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config')), "autokey")
-LOCK_FILE = CONFIG_DIR + "/autokey.pid"
-LOG_FILE = CONFIG_DIR + "/autokey.log"
+# Runtime dir falls back to cache dir, as a fallback is suggested by the spec
+XDG_CACHE_HOME = os.environ.get('XDG_CACHE_HOME', os.path.expanduser('~/.cache'))
+RUN_DIR = os.path.join(os.environ.get('XDG_RUNTIME_DIR', XDG_CACHE_HOME), "autokey")
+DATA_DIR = os.path.join(os.environ.get('XDG_DATA_HOME', os.path.expanduser("~/.local/share")), "autokey")
+
+LOCK_FILE = os.path.join(RUN_DIR, "autokey.pid")
+LOG_FILE = os.path.join(DATA_DIR, "autokey.log")
+
 MAX_LOG_SIZE = 5 * 1024 * 1024 # 5 megabytes
 MAX_LOG_COUNT = 3
 LOG_FORMAT = "%(asctime)s %(levelname)s - %(name)s - %(message)s"


### PR DESCRIPTION
Put autokey.log and autokey.lock in their proper places instead of in .config, fixes #106

It could be useful to check for the old log file location and (re)move it? I did not include that as I'm not sure if that is wise.

Sorry for all the whitespace changes - that was my editor. I can revert those if requested.
