### PR TITLE
docs(README): fix aur link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,7 @@ Arch Linux
 
 Available in the `AUR`_. Unfortunately, Arch has removed the kdebindings-python package, so only the GTK frontend is usable for now.
 
-.. _AUR: https://aur.archlinux.org/packages/autokey
-
+.. _AUR: https://aur.archlinux.org/packages/autokey-py3/ 
 Gentoo
 ++++++
 


### PR DESCRIPTION
I substituted the correct aur link for the autokey package.
It seems the package hosted on the aur uses the old name (autokey-py3) still.

Note: I noticed that there were other commits and merges to the master branch that were supposed to fix the link, but the link remains unfixed?  Not sure what's going on.