### PR TITLE
Followup to #121. Fix broken GTK dialog labels.

### DIFF
--- a/lib/autokey/gtkui/dialogs.py
+++ b/lib/autokey/gtkui/dialogs.py
@@ -37,18 +37,24 @@ from ..iomediator.key import Key
 from .configwindow0 import get_ui
 
 WORD_CHAR_OPTIONS = {
-                     "All non-word" : model.DEFAULT_WORDCHAR_REGEX,
-                     "Space and Enter" : r"[^ \n]",
-                     "Tab" : r"[^\t]"
+                     "All non-word": model.DEFAULT_WORDCHAR_REGEX,
+                     "Space and Enter": r"[^ \n]",
+                     "Tab": r"[^\t]"
                      }
 WORD_CHAR_OPTIONS_ORDERED = ["All non-word", "Space and Enter", "Tab"]
 
 EMPTY_FIELD_REGEX = re.compile(r"^ *$", re.UNICODE)
 
+
 def validate(expression, message, widget, parent):
     if not expression:
-        dlg = Gtk.MessageDialog(parent, Gtk.DialogFlags.MODAL|Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.WARNING,
-                                 Gtk.ButtonsType.OK, message)
+        dlg = Gtk.MessageDialog(
+            parent,
+            Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            Gtk.MessageType.WARNING,
+            Gtk.ButtonsType.OK,
+            message
+        )
         dlg.run()
         dlg.destroy()
         if widget is not None:
@@ -141,8 +147,7 @@ class AbbrSettingsDialog(DialogBase):
             self.abbrList.get_selection().select_iter(firstIter)
         else:
             self.removeButton.set_sensitive(False)
-            
-            
+
         self.removeTypedCheckbox.set_active(item.backspace)
         
         self.__resetWordCharCombo()
@@ -234,14 +239,17 @@ class AbbrSettingsDialog(DialogBase):
     def get_abbrs_readable(self):
         abbrs = self.get_abbrs()
         if len(abbrs) == 1:
-            return abbrs[0]#.encode("utf-8")
+            return abbrs[0]
         else:
-            return "[%s]" % ','.join(a for a in abbrs)
-            # return "[%s]" % ','.join([a.encode("utf-8") for a in abbrs])
+            return "[" + ",".join(abbrs) + "]"
             
     def valid(self):
-        if not validate(len(self.get_abbrs()) > 0, _("You must specify at least one abbreviation"),
-                            self.addButton, self.ui): return False
+        if not validate(
+                len(self.get_abbrs()) > 0,
+                _("You must specify at least one abbreviation"),
+                self.addButton,
+                self.ui):
+            return False
 
         return True
     
@@ -277,7 +285,6 @@ class AbbrSettingsDialog(DialogBase):
         else:
             self.abbrList.get_selection().select_iter(model.get_iter_first())
         
-        
     def on_abbrList_cursorchanged(self, widget, data=None):
         pass
     
@@ -302,7 +309,7 @@ class AbbrSettingsDialog(DialogBase):
 class HotkeySettingsDialog(DialogBase):
     
     KEY_MAP = {
-               ' ' : "<space>",
+               ' ': "<space>",
                }
     
     REVERSE_KEY_MAP = {}
@@ -424,8 +431,8 @@ class HotkeySettingsDialog(DialogBase):
         self.keyLabel.set_text(_("Key: ") + key)
         
     def valid(self):
-        if not validate(self.key is not None, _("You must specify a key for the hotkey."),
-                            None, self.ui): return False
+        if not validate(self.key is not None, _("You must specify a key for the hotkey."), None, self.ui):
+            return False
         
         return True
         
@@ -459,7 +466,6 @@ class GlobalHotkeyDialog(HotkeySettingsDialog):
         else:
             self.reset()
         
-        
     def save(self, item):
         # Build modifier list
         modifiers = self.build_modifiers()
@@ -473,20 +479,27 @@ class GlobalHotkeyDialog(HotkeySettingsDialog):
         assert key is not None, "Attempt to set hotkey with no key"
         item.set_hotkey(modifiers, key)
         
-        
     def valid(self):
         configManager = self.configManager
         modifiers = self.build_modifiers()
         regex = self.targetItem.get_applicable_regex()
         pattern = None
-        if regex is not None: pattern = regex.pattern
+        if regex is not None:
+            pattern = regex.pattern
 
         unique, conflicting = configManager.check_hotkey_unique(modifiers, self.key, pattern, self.targetItem)
-        if not validate(unique, _("The hotkey is already in use for %s.") % conflicting, None,
-                            self.ui): return False
+        if not validate(unique,
+                        _("The hotkey is already in use for %s.") % conflicting,
+                        None,
+                        self.ui):
+            return False
 
-        if not validate(self.key is not None, _("You must specify a key for the hotkey."),
-                            None, self.ui): return False
+        if not validate(
+                self.key is not None,
+                _("You must specify a key for the hotkey."),
+                None,
+                self.ui):
+            return False
         
         return True        
 
@@ -520,7 +533,6 @@ class WindowFilterSettingsDialog(DialogBase):
             self.triggerRegexEntry.set_text(item.get_filter_regex())
             self.recursiveButton.set_active(item.isRecursive)
             
-            
     def save(self, item):
         item.set_window_titles(self.get_filter_text())
         item.set_filter_recursive(self.get_is_recursive())
@@ -530,12 +542,11 @@ class WindowFilterSettingsDialog(DialogBase):
         self.recursiveButton.set_active(False)
         
     def get_filter_text(self):
-        return self.triggerRegexEntry.get_text()#.decode("utf-8")
+        return self.triggerRegexEntry.get_text()
         
     def get_is_recursive(self):
         return self.recursiveButton.get_active()
         
-    
     def valid(self):
         return True
     
@@ -564,7 +575,6 @@ class WindowFilterSettingsDialog(DialogBase):
         self.grabber.start()
     
         
-
 class DetectDialog(DialogBase):
 
     def __init__(self, parent):

--- a/lib/autokey/gtkui/dialogs.py
+++ b/lib/autokey/gtkui/dialogs.py
@@ -424,14 +424,14 @@ class HotkeySettingsDialog(DialogBase):
         self.keyLabel.set_text(_("Key: ") + key)
         
     def valid(self):
-        if not validate(self.key is not None, _("You must specify a key for the hot"),
+        if not validate(self.key is not None, _("You must specify a key for the hotkey."),
                             None, self.ui): return False
         
         return True
         
     def on_setButton_pressed(self, widget, data=None):
         self.setButton.set_sensitive(False)
-        self.keyLabel.set_text(_("Press a .."))
+        self.keyLabel.set_text(_("Press a key..."))
         self.grabber = iomediator.KeyGrabber(self)
         self.grabber.start()
         
@@ -485,7 +485,7 @@ class GlobalHotkeyDialog(HotkeySettingsDialog):
         if not validate(unique, _("The hotkey is already in use for %s.") % conflicting, None,
                             self.ui): return False
 
-        if not validate(self.key is not None, _("You must specify a key for the hot"),
+        if not validate(self.key is not None, _("You must specify a key for the hotkey."),
                             None, self.ui): return False
         
         return True        

--- a/lib/autokey/iomediator/_iomediator.py
+++ b/lib/autokey/iomediator/_iomediator.py
@@ -40,7 +40,7 @@ class IoMediator(threading.Thread):
                           Key.SHIFT: False,
                           Key.SUPER: False,
                           Key.HYPER: False,
-                          Key.META : False,
+                          Key.META: False,
                           Key.CAPSLOCK: False,
                           Key.NUMLOCK: False
                           }
@@ -87,7 +87,7 @@ class IoMediator(threading.Thread):
         """
         _logger.debug("%s released", modifier)
         # Caps and num lock are handled on key down only
-        if not modifier in (Key.CAPSLOCK, Key.NUMLOCK):
+        if modifier not in (Key.CAPSLOCK, Key.NUMLOCK):
             self.modifiers[modifier] = False
     
     def handle_keypress(self, keyCode, windowName, windowClass):
@@ -132,7 +132,7 @@ class IoMediator(threading.Thread):
         
         _logger.debug("Send via event interface")
         self.__clearModifiers()
-        modifiers = []            
+        modifiers = []
         for section in KEY_SPLIT_RE.split(string):
             if len(section) > 0:
                 if Key.is_key(section[:-1]) and section[-1] == '+' and section[:-1] in MODIFIERS:
@@ -163,9 +163,9 @@ class IoMediator(threading.Thread):
         if len(string) > 0:
             _logger.debug("Send via clipboard")
             self.interface.send_string_clipboard(string, pasteCommand)
-        
+
     def remove_string(self, string):
-        backspaces = -1 # Start from -1 to discount the backspace already pressed by the user
+        backspaces = -1  # Start from -1 to discount the backspace already pressed by the user
         
         for section in KEY_SPLIT_RE.split(string):
             if Key.is_key(section):
@@ -174,15 +174,15 @@ class IoMediator(threading.Thread):
                 backspaces += len(section)
                 
         self.send_backspace(backspaces)
-        
+
     def send_key(self, keyName):
         keyName = keyName.replace('\n', "<enter>")
         self.interface.send_key(keyName)
-        
+
     def press_key(self, keyName):
         keyName = keyName.replace('\n', "<enter>")
         self.interface.fake_keydown(keyName)
-        
+
     def release_key(self, keyName):
         keyName = keyName.replace('\n', "<enter>")
         self.interface.fake_keyup(keyName)                
@@ -197,7 +197,7 @@ class IoMediator(threading.Thread):
         """
         for i in range(count):
             self.interface.send_key(Key.LEFT)
-        
+
     def send_right(self, count):
         for i in range(count):
             self.interface.send_key(Key.RIGHT)
@@ -208,20 +208,20 @@ class IoMediator(threading.Thread):
         """        
         for i in range(count):
             self.interface.send_key(Key.UP)
-        
+
     def send_backspace(self, count):
         """
         Sends the given number of backspace key presses.
         """
         for i in range(count):
             self.interface.send_key(Key.BACKSPACE)
-        
+
     def send_mouse_click(self, x, y, button, relative):
         self.interface.send_mouse_click(x, y, button, relative)
-        
+
     def send_mouse_click_relative(self, x, y, button):
         self.interface.send_mouse_click_relative(x, y, button)
-            
+
     def flush(self):
         self.interface.flush()
         
@@ -231,14 +231,14 @@ class IoMediator(threading.Thread):
         self.releasedModifiers = []
         
         for modifier in list(self.modifiers.keys()):
-            if self.modifiers[modifier] and not modifier in (Key.CAPSLOCK, Key.NUMLOCK):
+            if self.modifiers[modifier] and modifier not in (Key.CAPSLOCK, Key.NUMLOCK):
                 self.releasedModifiers.append(modifier)
                 self.interface.release_key(modifier)
-        
+
     def __reapplyModifiers(self):
         for modifier in self.releasedModifiers:
             self.interface.press_key(modifier)
-            
+
     def __getModifiersOn(self):
         modifiers = []
         for modifier in HELD_MODIFIERS:

--- a/lib/autokey/iomediator/_keygrabber.py
+++ b/lib/autokey/iomediator/_keygrabber.py
@@ -7,7 +7,6 @@ from .key import Key
 from . import _iomediator
 
 
-
 class KeyGrabber:
     """
     Keygrabber used by the hotkey settings dialog to grab the key pressed
@@ -24,7 +23,7 @@ class KeyGrabber:
         _iomediator.CURRENT_INTERFACE.grab_keyboard()
 
     def handle_keypress(self, rawKey, modifiers, key, *args):
-        if not rawKey in MODIFIERS:
+        if rawKey not in MODIFIERS:
             IoMediator.listeners.remove(self)
             self.targetParent.set_key(rawKey, modifiers)
             _iomediator.CURRENT_INTERFACE.ungrab_keyboard()
@@ -60,7 +59,6 @@ class Recorder(KeyGrabber):
         self.delay = 0
         self.delayFinished = True
         _iomediator.CURRENT_INTERFACE.grab_keyboard()
-
 
     def stop(self):
         if self in IoMediator.listeners:
@@ -103,7 +101,7 @@ class Recorder(KeyGrabber):
                     (Key.SHIFT in modifiers and len(rawKey) > 1):
                 self.targetParent.append_hotkey(rawKey, modifiers)
 
-            elif not key in MODIFIERS:
+            elif key not in MODIFIERS:
                 self.targetParent.append_key(key)
 
     def handle_mouseclick(self, rootX, rootY, relX, relY, button, windowInfo):


### PR DESCRIPTION
It looks like my usage of the "search and replace" functionality truncated labels in GTK dialogs [here](https://github.com/autokey/autokey/pull/121/commits/869611954b5b81fa004ece64732af0b91f97a6b8).
This pull request fixes those labels and, while at it, fixes some minor code style issues.