### PR TITLE
Autokey package has been updated and pushed to Fedora

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,15 @@ Available via layman_.
 Fedora
 ++++++
 
-Build package using provided .spec file (may be outdated)
+Avaiable from Fedora_ 27 onwards.
+
+.. _Fedora: https://apps.fedoraproject.org/packages/autokey
+
+.. code:: sh
+
+   sudo dnf install autokey-gtk
+   # or for kde
+   sudo dnf install autokey-kde
 
 Documentation
 =============


### PR DESCRIPTION
The package has been updated to the latest release 0.94.0 and pushed to Fedora 27 and 28. I have verified its working correctly on gnome and KDE.