### PR TITLE
interface.py Bugfix: Fix the mouse selection paste mode in autokey-gtk.

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -570,8 +570,7 @@ class XInterfaceBase(threading.Thread):
             self.sem.release()
         else:
             Gdk.threads_enter()
-            self.selection.set_text(string)
-            # self.selection.set_text(string.encode("utf-8"))
+            self.selection.set_text(string, -1)  # second parameter is string length, -1 means "autodetect"
             Gdk.threads_leave()
 
     def __fillClipboard(self, string):


### PR DESCRIPTION
Using the »Mouse Selection« paste mode for phrases crashed autokey-gtk,
which is fixed in this commit by adding the required length parameter to Gtk.Clipboard.set_text().

This bug was mentioned here:
https://github.com/autokey/autokey/issues/151#issuecomment-392834453

