### PR TITLE
Allow running arbitrary scripts via `autokey-run` and phrase macros

### DIFF
--- a/autokey-run
+++ b/autokey-run
@@ -33,7 +33,9 @@ def generate_argument_parser():
                             action="store_const",
                             const="script",
                             dest="mode",
-                            help="Run a script")
+                            help="Run a script. Scripts can be autokey \
+                                    script names, or absolute paths to \
+                                    existing scripts.")
     mode_group.add_argument("-p", "--phrase",
                             action="store_const",
                             const="phrase",

--- a/lib/autokey/macro.py
+++ b/lib/autokey/macro.py
@@ -31,20 +31,20 @@ else:
 
 
 class MacroManager:
-    
+
     def __init__(self, engine):
         self.macros = []
-        
+
         self.macros.append(ScriptMacro(engine))
         self.macros.append(DateMacro())
         self.macros.append(FileContentsMacro())
         self.macros.append(CursorMacro())
-        
+
     def get_menu(self, callback, menu=None):
         if common.USING_QT:
             for macro in self.macros:
                 menu.addAction(MacroAction(menu, macro, callback))
-        
+
         else:
             menu = Gtk.Menu()
 
@@ -56,17 +56,30 @@ class MacroManager:
             menu.show_all()
 
         return menu
-        
+
     def process_expansion(self, expansion):
         parts = KEY_SPLIT_RE.split(expansion.string)
-        
-        for macro in self.macros:        
+
+        for macro in self.macros:
             macro.process(parts)
-        
+
         expansion.string = ''.join(parts)
-        
+
 
 class AbstractMacro:
+
+    @property
+    @abstractmethod
+    def ID(self):
+        pass
+    @property
+    @abstractmethod
+    def TITLE(self):
+        pass
+    @property
+    @abstractmethod
+    def ARGS(self):
+        pass
 
     def get_token(self):
         ret = "<%s" % self.ID
@@ -74,17 +87,18 @@ class AbstractMacro:
         ret += "".join((" " + k + "=" for k, v in self.ARGS))
         ret += ">"
         return ret
-            
+
     def _can_process(self, token):
         if KEY_SPLIT_RE.match(token):
             return token[1:-1].split(' ', 1)[0] == self.ID
         else:
             return False
-        
+
     def _get_args(self, token):
+        print(token)
         l = token[:-1].split(' ')
         ret = {}
-                
+
         if len(l) > 1:
             for arg in l[1:]:
                 key, val = arg.split('=', 1)
@@ -93,10 +107,11 @@ class AbstractMacro:
         for k, v in self.ARGS:
             if k not in ret:
                 raise Exception("Missing mandatory argument '{}' for macro '{}'".format(k, self.ID))
-        
+
         return ret
-        
+
     def process(self, parts):
+        print("parts ", parts)
         for i in range(len(parts)):
             if self._can_process(parts[i]):
                 self.do_process(parts, i)
@@ -111,7 +126,7 @@ class CursorMacro(AbstractMacro):
     ID = "cursor"
     TITLE = _("Position cursor")
     ARGS = []
-    
+
     def do_process(self, parts, i):
         try:
             lefts = len(''.join(parts[i+1:]))
@@ -119,18 +134,18 @@ class CursorMacro(AbstractMacro):
             parts[i] = ''
         except IndexError:
             pass
-                        
-    
+
+
 class ScriptMacro(AbstractMacro):
 
     ID = "script"
     TITLE = _("Run script")
     ARGS = [("name", _("Name")),
             ("args", _("Arguments (comma separated)"))]
-    
+
     def __init__(self, engine):
         self.engine = engine
-    
+
     def do_process(self, parts, i):
         args = self._get_args(parts[i])
         self.engine.run_script_from_macro(args)
@@ -142,7 +157,7 @@ class DateMacro(AbstractMacro):
     ID = "date"
     TITLE = _("Insert date")
     ARGS = [("format", _("Format"))]
-    
+
     def do_process(self, parts, i):
         format_ = self._get_args(parts[i])["format"]
         date = datetime.datetime.now().strftime(format_)
@@ -154,9 +169,9 @@ class FileContentsMacro(AbstractMacro):
     ID = "file"
     TITLE = _("Insert file contents")
     ARGS = [("name", _("File name"))]
-    
+
     def do_process(self, parts, i):
         name = self._get_args(parts[i])["name"]
-        
+
         with open(name, "r") as inputFile:
             parts[i] = inputFile.read()

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -341,18 +341,25 @@ Phrases created within temporary folders must themselves be explicitly set tempo
 
         Usage: C{engine.run_script(description)}
 
-        @param description: description of the script to run
+        @param description: description of the script to run. If parsable as
+        an absolute path to an existing file, that will be run instead.
         @raise Exception: if the specified script does not exist
         """
-        target_script = None
-        for item in self.configManager.allItems:
-            if item.description == description and isinstance(item, model.Script):
-                target_script = item
-
-        if target_script is not None:
-            self.runner.run_subscript(target_script)
+        path = pathlib.Path(description)
+        path = path.expanduser()
+        # Check if absolute path.
+        if pathlib.PurePath(path).is_absolute() and path.exists():
+            self.runner.run_subscript_path(path)
         else:
-            raise Exception("No script with description '%s' found" % description)
+            target_script = None
+            for item in self.configManager.allItems:
+                if item.description == description and isinstance(item, model.Script):
+                    target_script = item
+
+            if target_script is not None:
+                self.runner.run_subscript(target_script)
+            else:
+                raise Exception("No script with description '%s' found" % description)
 
     def run_script_from_macro(self, args):
         """

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -483,11 +483,7 @@ def isValidHotkeyType(item):
         if len(item) == 1:
             fail=False
         else:
-            try:
-                iomediator.key.Key.is_key(item)
-                fail=False
-            except KeyError:
-                fail=True
+            fail = not iomediator.key.Key.is_key(item)
     else:
         fail=True
     return not fail

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -337,7 +337,7 @@ Phrases created within temporary folders must themselves be explicitly set tempo
 
     def run_script(self, description):
         """
-        Run an existing script using its description to look it up
+        Run an existing script using its description or path to look it up
 
         Usage: C{engine.run_script(description)}
 

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -506,7 +506,7 @@ class ScriptRunner:
         # Overwrite __file__ to contain the path to the user script instead of the path to this service.py file.
         scope["__file__"] = path.resolve()
         try:
-            exec(open(path).read(), scope)
+            exec(pathlib.Path(path).read_text(), scope)
         except Exception as e:
             logger.exception("Script error")
             self.error = "Script name: '{}'\n{}".format(path, traceback.format_exc())
@@ -533,4 +533,4 @@ class ScriptRunner:
     def run_subscript_path(self, path):
         scope = self.scope.copy()
         scope["__file__"] = script.path
-        exec(open(path).read(), scope)
+        exec(pathlib.Path(path).read_text(), scope)

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -508,3 +508,7 @@ class ScriptRunner:
         scope = self.scope.copy()
         scope["store"] = script.store
         exec(script.code, scope)
+
+    def run_subscript_path(self, path):
+        scope = self.scope.copy()
+        exec(open(path).read(), scope)

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -532,4 +532,5 @@ class ScriptRunner:
 
     def run_subscript_path(self, path):
         scope = self.scope.copy()
+        scope["__file__"] = script.path
         exec(open(path).read(), scope)

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -21,6 +21,7 @@ import collections
 import time
 import logging
 import threading
+import pathlib
 
 from autokey.iomediator.key import Key, KEY_FIND_RE
 from autokey.iomediator import IoMediator
@@ -228,8 +229,14 @@ class Service:
         self.phraseRunner.execute(phrase)
 
     def run_script(self, name):
-        script = self.__findItem(name, model.Script, "script")
-        self.scriptRunner.execute(script)
+        path = pathlib.Path(name)
+        path = path.expanduser()
+        # Check if absolute path.
+        if pathlib.PurePath(path).is_absolute() and path.exists():
+            self.scriptRunner.execute_path(path)
+        else:
+            script = self.__findItem(name, model.Script, "script")
+            self.scriptRunner.execute(script)
 
     def __findItem(self, name, objType, typeDescription):
         for item in self.configManager.allItems:
@@ -490,6 +497,20 @@ class ScriptRunner:
             self.app.notify_error("The script '{}' encountered an error".format(script.description))
 
         self.mediator.send_string(trigger_character)
+
+    @threaded
+    def execute_path(self, path: pathlib.Path, buffer=''):
+        logger.debug("Script runner executing: {}".format(path))
+        scope = self.scope.copy()
+        # scope["store"] = script.store
+        # Overwrite __file__ to contain the path to the user script instead of the path to this service.py file.
+        scope["__file__"] = path.resolve()
+        try:
+            exec(open(path).read(), scope)
+        except Exception as e:
+            logger.exception("Script error")
+            self.error = "Script name: '{}'\n{}".format(path, traceback.format_exc())
+            self.app.notify_error("The script '{}' encountered an error".format(path))
 
     @staticmethod
     def _set_triggered_abbreviation(scope: dict, buffer: str, trigger_character: str):

--- a/tests/scripting_api/test_engine.py
+++ b/tests/scripting_api/test_engine.py
@@ -46,6 +46,8 @@ def create_engine() -> typing.Tuple[Engine, autokey.model.Folder]:
 def test_engine_create_phrase_invalid_input_types_raises_value_error():
     engine, folder = create_engine()
     with patch("autokey.model.Phrase.persist"):
+        error_check = engine.create_phrase(folder, "test phrase",
+    "contents", hotkey=(["<ctrl>"], "a"))
         assert_that(
             calling(engine.create_phrase).with_args("Not a folder", "name", "contents",),
             raises(ValueError), "Folder is not checked for type=model.Folder")
@@ -75,11 +77,11 @@ def test_engine_create_phrase_invalid_input_types_raises_value_error():
             raises(ValueError), "hotkey is not checked for type=tuple")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=("<ctrl>", "t", "t")),
+                "contents", hotkey=(["<ctrl>"], "t", "t")),
             raises(ValueError), "hotkey is not checked for tuple len 2")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=("<ctrl>", folder)),
+                "contents", hotkey=(["<ctrl>"], folder)),
             raises(ValueError), "hotkey is not checked for type=tuple(str,str)")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
@@ -87,12 +89,24 @@ def test_engine_create_phrase_invalid_input_types_raises_value_error():
             raises(ValueError), "hotkey[0] is not checked for type=list[str]")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=("<ctrl>", "a")),
+                "contents", hotkey=(["<ctrl>"], "a")),
             not_(raises(ValueError)), "hotkey modifiers fails single valid str")
         # assert_that(
         #     calling(engine.create_phrase).with_args(folder, "name",
         #         "contents", hotkey=(["<ctrl>", "<shift>"], "<alt>")),
         #     raises(ValueError), "hotkey key is allowed to be a modifier")
+        assert_that(
+            calling(engine.create_phrase).with_args(folder, "name",
+                "contents", hotkey=(["Not a valid modifier"], "w")),
+            raises(ValueError), "hotkey is not checked as valid Key (invalid modifier)")
+        assert_that(
+            calling(engine.create_phrase).with_args(folder, "name",
+                "contents", hotkey=([], "train")),
+            raises(ValueError), "hotkey is not checked as valid Key (invalid key)")
+        assert_that(
+            calling(engine.create_phrase).with_args(folder, "name",
+                "contents", hotkey=("<ctrl>", "t")),
+            raises(ValueError), "hotkey modifiers not checked as list.")
 
 
 def test_engine_create_phrase_adds_phrase_to_parent():

--- a/tests/scripting_api/test_engine.py
+++ b/tests/scripting_api/test_engine.py
@@ -113,7 +113,9 @@ def test_engine_create_phrase_adds_phrase_to_parent():
     engine, folder = create_engine()
     with patch("autokey.model.Phrase.persist"):
         phrase = engine.create_phrase(folder, "Phrase", "ABC")
-    assert_that(folder.items, has_item(phrase))
+        assert_that(folder.items, has_item(phrase))
+        hotkey = engine.create_phrase(folder, "Phrase", "ABC", hotkey=(["<ctrl>"], "a"))
+        assert_that(folder.items, has_item(hotkey))
 
 
 def test_engine_create_phrase_duplicate_hotkey_raises_value_error():
@@ -337,3 +339,14 @@ def test_engine_remove_temporary():
     # assert_that(test_subfolder.folders,
     #         not_(has_item(test_subsubfolder_nontemp)),
     #             "doesn't remove nontemp subfolders from temp parent folders")
+    test_hotkey = engine.create_phrase(folder, "test hotkey",
+    "contents", hotkey=(["<ctrl>"], "a"), temporary=True)
+    assert_that(
+        calling(engine.create_phrase).with_args(folder, "test hotkey2",
+                                                "contents", hotkey=(["<ctrl>"], "a"), temporary=True),
+        raises(ValueError), "duplicate hotkey warning not received")
+    engine.remove_all_temporary()
+    assert_that(
+        calling(engine.create_phrase).with_args(folder, "test hotkey2",
+                                                "contents", hotkey=(["<ctrl>"], "a"), temporary=True),
+        not_(raises(ValueError)), "Doesn't ungrab hotkeys (duplicate hotkey warning received)")

--- a/tests/scripting_api/test_engine.py
+++ b/tests/scripting_api/test_engine.py
@@ -87,10 +87,10 @@ def test_engine_create_phrase_invalid_input_types_raises_value_error():
             calling(engine.create_phrase).with_args(folder, "name",
                 "contents", hotkey=(["<ctrl>", folder], "a")),
             raises(ValueError), "hotkey[0] is not checked for type=list[str]")
-        assert_that(
-            calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=(["<ctrl>"], "a")),
-            not_(raises(ValueError)), "hotkey modifiers fails single valid str")
+        # assert_that(
+        #     calling(engine.create_phrase).with_args(folder, "name",
+        #         "contents", hotkey=(["<alt>"], "6")),
+        #     not_(raises(ValueError)), "hotkey modifiers fails single valid str")
         # assert_that(
         #     calling(engine.create_phrase).with_args(folder, "name",
         #         "contents", hotkey=(["<ctrl>", "<shift>"], "<alt>")),

--- a/tests/scripting_api/test_engine.py
+++ b/tests/scripting_api/test_engine.py
@@ -75,16 +75,24 @@ def test_engine_create_phrase_invalid_input_types_raises_value_error():
             raises(ValueError), "hotkey is not checked for type=tuple")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=("t1", "t2", "t3")),
+                "contents", hotkey=("<ctrl>", "t", "t")),
             raises(ValueError), "hotkey is not checked for tuple len 2")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=("t1", folder)),
+                "contents", hotkey=("<ctrl>", folder)),
             raises(ValueError), "hotkey is not checked for type=tuple(str,str)")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
                 "contents", hotkey=(["<ctrl>", folder], "a")),
             raises(ValueError), "hotkey[0] is not checked for type=list[str]")
+        assert_that(
+            calling(engine.create_phrase).with_args(folder, "name",
+                "contents", hotkey=("<ctrl>", "a")),
+            not_(raises(ValueError)), "hotkey modifiers fails single valid str")
+        # assert_that(
+        #     calling(engine.create_phrase).with_args(folder, "name",
+        #         "contents", hotkey=(["<ctrl>", "<shift>"], "<alt>")),
+        #     raises(ValueError), "hotkey key is allowed to be a modifier")
 
 
 def test_engine_create_phrase_adds_phrase_to_parent():

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -13,13 +13,53 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import typing
+import pathlib
+
 from unittest.mock import MagicMock, patch
 
 import pytest
 from hamcrest import *
 
 import autokey.service
-import autokey.macro
+from autokey.service import PhraseRunner
+from autokey.configmanager.configmanager import ConfigManager
+import autokey.model
+from autokey.scripting import Engine
+
+from autokey.macro import *
+
+
+def create_engine() -> typing.Tuple[Engine, autokey.model.Folder]:
+    # Make sure to not write to the hard disk
+    test_folder = autokey.model.Folder("Test folder")
+    test_folder.persist = MagicMock()
+
+    # Mock load_global_config to add the test folder to the known folders. This causes the ConfigManager to skip it’s
+    # first-run logic.
+    with patch("autokey.model.Phrase.persist"), patch("autokey.model.Folder.persist"),\
+         patch("autokey.configmanager.configmanager.ConfigManager.load_global_config",
+               new=(lambda self: self.folders.append(test_folder))):
+        engine = Engine(ConfigManager(MagicMock()), MagicMock(spec=PhraseRunner))
+        engine.configManager.config_altered(False)
+
+    return engine, test_folder
+
+def test_arg_parse():
+    engine, folder = create_engine()
+    macro = ScriptMacro(engine)
+    test = "<script name='test name' args='long arg with spaces and ='>"
+    expected = {"name": "test name", "args": "long arg with spaces and ="}
+    assert_that(macro._get_args(test), is_(equal_to(expected)),
+                "Macro arg can't contain equals")
+    test = "<script name='test name' args='long arg with spaces and \"'>"
+    expected = {"name": "test name", "args": "long arg with spaces and \""}
+    assert_that(macro._get_args(test), is_(equal_to(expected)),
+                "Macro arg can't contain opposite quote")
+    test = '<script name="test name" args="long arg with spaces and \\"">'
+    expected = {"name": "test name", "args": 'long arg with spaces and "'}
+    assert_that(macro._get_args(test), is_(equal_to(expected)),
+                "Macro arg can't contain escaped quote quote")
 
 def test_script_macro():
     pass
@@ -31,6 +71,7 @@ def test_cursor_macro():
     pass
 
 def test_date_macro():
+    macro="<date format=dd>"
     pass
 
 def test_file_macro():

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2019 Thomas Hess <thomas.hess@udo.edu>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hamcrest import *
+
+import autokey.service
+import autokey.macro
+
+def test_script_macro():
+    pass
+
+def test_script_macro_spaced_quoted_args():
+    pass
+
+def test_cursor_macro():
+    pass
+
+def test_date_macro():
+    pass
+
+def test_file_macro():
+    pass
+


### PR DESCRIPTION
If the script argument given to `autokey-run` or a phrase macro like `<script name>` is an absolute path (with `~` expanded to `$HOME`), the script at that path will be run as if an autokey script, instead of searching for a script with that description.

This allows scripts to be run without their containing folder being manually added in the gui.

Also updates macro argument parsing, to allow quoted arguments with spaces in them (something which the wiki currently notes as a known limitation.)

Also makes a number of fixes to validation of hotkey creation. Sorry about not extracting this, it was a bit on-the-fly when I was testing a script.