### PR TITLE
Close #246: Allow engine.run_script to accept keyword arguments

### DIFF
--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -378,7 +378,7 @@ Phrases created within temporary folders must themselves be explicitly set tempo
         Usage: C{engine.get_script_arguments()}
 
         @return: the arguments
-        @rtype: C{list(str())}
+        @rtype: C{list[Any]}
         """
         return self._script_args
 
@@ -390,7 +390,7 @@ Phrases created within temporary folders must themselves be explicitly set tempo
         Usage: C{engine.get_script_keyword_arguments()}
 
         @return: the arguments
-        @rtype: C{dict(str():str())}
+        @rtype: C{Dict[str, Any]}
         """
         return self._script_kwargs
 

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -37,6 +37,8 @@ class Engine:
         self.runner = runner
         self.monitor = config_manager.app.monitor
         self._macro_args = []
+        self._script_args = []
+        self._script_kwargs = {}
         self._return_value = ''
         self._triggered_abbreviation = None  # type: Optional[str]
 
@@ -335,15 +337,19 @@ Phrases created within temporary folders must themselves be explicitly set tempo
         self.monitor.unsuspend()
         self.configManager.config_altered(False)
 
-    def run_script(self, description):
+    def run_script(self, description, *args, **kwargs):
         """
         Run an existing script using its description to look it up
 
-        Usage: C{engine.run_script(description)}
+        Usage: C{engine.run_script(description, 'foo', 'bar', foobar='foobar'})}
 
         @param description: description of the script to run
+        @param args: arguments to pass to the function
+        @param kwargs: arguments to pass to the function by key
         @raise Exception: if the specified script does not exist
         """
+        self._script_args = args
+        self._script_kwargs = kwargs
         target_script = None
         for item in self.configManager.allItems:
             if item.description == description and isinstance(item, model.Script):
@@ -364,6 +370,29 @@ Phrases created within temporary folders must themselves be explicitly set tempo
             self.run_script(args["name"])
         except Exception as e:
             self.set_return_value("{ERROR: %s}" % str(e))
+
+    def get_script_arguments(self):
+        """
+        Get the arguments supplied to the current script via the scripting api
+
+        Usage: C{engine.get_script_arguments()}
+
+        @return: the arguments
+        @rtype: C{list(str())}
+        """
+        return self._script_args
+
+    def get_script_keyword_arguments(self):
+        """
+        Get the arguments supplied to the current script via the scripting api
+        as keyword args.
+
+        Usage: C{engine.get_script_keyword_arguments()}
+
+        @return: the arguments
+        @rtype: C{dict(str():str())}
+        """
+        return self._script_kwargs
 
     def get_macro_arguments(self):
         """

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -357,6 +357,7 @@ Phrases created within temporary folders must themselves be explicitly set tempo
 
         if target_script is not None:
             self.runner.run_subscript(target_script)
+            return self._return_value
         else:
             raise Exception("No script with description '%s' found" % description)
 
@@ -369,6 +370,8 @@ Phrases created within temporary folders must themselves be explicitly set tempo
         try:
             self.run_script(args["name"])
         except Exception as e:
+            # TODO: Log more information here, instead of setting the return
+            # value.
             self.set_return_value("{ERROR: %s}" % str(e))
 
     def get_script_arguments(self):

--- a/tests/scripting_api/set_return_kwargs.py
+++ b/tests/scripting_api/set_return_kwargs.py
@@ -1,0 +1,2 @@
+kwargs = engine.get_script_keyword_arguments()
+engine.set_return_value(kwargs["arg1"])

--- a/tests/scripting_api/test_engine.py
+++ b/tests/scripting_api/test_engine.py
@@ -328,7 +328,4 @@ def test_run_script():
     with patch("autokey.model.Phrase.persist"), patch("autokey.model.Folder.persist"):
         dummy_folder = autokey.model.Folder("dummy")
         script = get_autokey_dir() + "/tests/scripting_api/set_return_kwargs.py"
-        # This also won't work until merging the absolute path script run
-        # patch.
-        engine.run_script(script, arg1="arg 1")
-        assert_that(engine._get_return_value["arg1"], is_(equal_to("arg 1")))
+        assert_that(engine.run_script(script, arg1="arg 1"), is_(equal_to("arg 1")))

--- a/tests/scripting_api/test_engine.py
+++ b/tests/scripting_api/test_engine.py
@@ -15,6 +15,8 @@
 
 import typing
 import pathlib
+import sys
+import os
 
 from unittest.mock import MagicMock, patch
 
@@ -26,6 +28,8 @@ from autokey.service import PhraseRunner
 import autokey.model
 from autokey.scripting import Engine
 
+def get_autokey_dir():
+    return os.path.dirname(os.path.realpath(sys.argv[0]))
 
 def create_engine() -> typing.Tuple[Engine, autokey.model.Folder]:
     # Make sure to not write to the hard disk
@@ -315,3 +319,16 @@ def test_engine_remove_temporary():
     # assert_that(test_subfolder.folders,
     #         not_(has_item(test_subsubfolder_nontemp)),
     #             "doesn't remove nontemp subfolders from temp parent folders")
+
+
+@pytest.mark.skip(reason="For this to work, engine needs to be initialised with a PhraseRunner that isn't a mock. Sadly, that requires an app that isn't a mock.")
+def test_run_script():
+    # Makes use of running script from absolute path.
+    engine, folder = create_engine()
+    with patch("autokey.model.Phrase.persist"), patch("autokey.model.Folder.persist"):
+        dummy_folder = autokey.model.Folder("dummy")
+        script = get_autokey_dir() + "/tests/scripting_api/set_return_kwargs.py"
+        # This also won't work until merging the absolute path script run
+        # patch.
+        engine.run_script(script, arg1="arg 1")
+        assert_that(engine._get_return_value["arg1"], is_(equal_to("arg 1")))


### PR DESCRIPTION
I wrote a test, but it won't work until #339 is merged, because it uses an absolute path to the test script to make things easier.
