### PR TITLE
Add new macro: `<system command=>`

### DIFF
--- a/lib/autokey/macro.py
+++ b/lib/autokey/macro.py
@@ -84,6 +84,7 @@ class MacroManager:
         self.macros.append(DateMacro())
         self.macros.append(FileContentsMacro())
         self.macros.append(CursorMacro())
+        self.macros.append(SystemMacro(engine))
 
     def get_menu(self, callback, menu=None):
         if common.USING_QT:
@@ -212,7 +213,28 @@ class ScriptMacro(AbstractMacro):
         macro_type, macro = self._extract_macro(sections[i])
         args = self._get_args(macro)
         self.engine.run_script_from_macro(args)
-        return self.engine._get_return_value()
+        sections[i] = self.engine._get_return_value()
+        return sections
+
+
+class SystemMacro(AbstractMacro):
+
+    ID = "system"
+    TITLE = _("Run system command")
+    ARGS = [("command", _("Command to be executed (including any arguments) - e.g. 'ls -l'")),]
+            # ("getOutput", _("True or False, whether or not to set the return
+            #     value to the script's stdout (blocks until script finishes). If
+            #     false, "))]
+
+    def __init__(self, engine):
+        self.engine = engine
+
+    def do_process(self, sections, i):
+        macro_type, macro = self._extract_macro(sections[i])
+        args = self._get_args(macro)
+        self.engine.run_system_command_from_macro(args)
+        sections[i] =  self.engine._get_return_value()
+        return sections
 
 
 class DateMacro(AbstractMacro):

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -206,6 +206,7 @@ Folders created within temporary folders must themselves be set temporary")
           It can be used for _really_ advanced use cases, where further customizations are desired. Use at your own
           risk. No guarantees are made about the object’s structure. Read the AutoKey source code for details.
         """
+
         # Start with input type-checking.
         validateType(folder, "folder", model.Folder)
         # For when we allow pathlib.Path
@@ -341,18 +342,25 @@ Phrases created within temporary folders must themselves be explicitly set tempo
 
         Usage: C{engine.run_script(description)}
 
-        @param description: description of the script to run
+        @param description: description of the script to run. If parsable as
+        an absolute path to an existing file, that will be run instead.
         @raise Exception: if the specified script does not exist
         """
-        target_script = None
-        for item in self.configManager.allItems:
-            if item.description == description and isinstance(item, model.Script):
-                target_script = item
-
-        if target_script is not None:
-            self.runner.run_subscript(target_script)
+        path = pathlib.Path(description)
+        path = path.expanduser()
+        # Check if absolute path.
+        if pathlib.PurePath(path).is_absolute() and path.exists():
+            self.runner.run_subscript_path(path)
         else:
-            raise Exception("No script with description '%s' found" % description)
+            target_script = None
+            for item in self.configManager.allItems:
+                if item.description == description and isinstance(item, model.Script):
+                    target_script = item
+
+            if target_script is not None:
+                self.runner.run_subscript(target_script)
+            else:
+                raise Exception("No script with description '%s' found" % description)
 
     def run_script_from_macro(self, args):
         """
@@ -493,8 +501,8 @@ def validateHotkey(hotkey):
                     for item in hotkey[0]:
                         if not isValidHotkeyType(item):
                             fail=True
-                elif not isValidHotkeyType(hotkey[0]):
-                    fail=True
+                elif isValidHotkeyType(hotkey[0]):
+                    pass
                 else:
                     fail=True
                 # Then check second element is a key or str

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -20,6 +20,7 @@ from collections.abc import Iterable
 from typing import Tuple, Optional, List, Union
 
 from autokey import model, iomediator
+from autokey.scripting.system import System
 
 
 class Engine:
@@ -369,6 +370,16 @@ Phrases created within temporary folders must themselves be explicitly set tempo
 
         try:
             self.run_script(args["name"])
+        except Exception as e:
+            self.set_return_value("{ERROR: %s}" % str(e))
+
+    def run_system_command_from_macro(self, args):
+        """
+        Used internally by AutoKey for system macros
+        """
+
+        try:
+            self._return_value = System.exec_command(args["command"], getOutput=True)
         except Exception as e:
             self.set_return_value("{ERROR: %s}" % str(e))
 

--- a/lib/autokey/scripting/system.py
+++ b/lib/autokey/scripting/system.py
@@ -21,7 +21,7 @@ class System:
     Simplified access to some system commands.
     """
 
-    def exec_command(self, command, getOutput=True):
+    def exec_command(command, getOutput=True):
         """
         Execute a shell command
 
@@ -49,7 +49,7 @@ class System:
         else:
             subprocess.Popen(command, shell=True, bufsize=-1)
 
-    def create_file(self, fileName, contents=""):
+    def create_file(fileName, contents=""):
         """
         Create a file with contents
 

--- a/tests/scripting_api/test_engine.py
+++ b/tests/scripting_api/test_engine.py
@@ -75,16 +75,24 @@ def test_engine_create_phrase_invalid_input_types_raises_value_error():
             raises(ValueError), "hotkey is not checked for type=tuple")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=("t1", "t2", "t3")),
+                "contents", hotkey=("<ctrl>", "t", "t")),
             raises(ValueError), "hotkey is not checked for tuple len 2")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
-                "contents", hotkey=("t1", folder)),
+                "contents", hotkey=("<ctrl>", folder)),
             raises(ValueError), "hotkey is not checked for type=tuple(str,str)")
         assert_that(
             calling(engine.create_phrase).with_args(folder, "name",
                 "contents", hotkey=(["<ctrl>", folder], "a")),
             raises(ValueError), "hotkey[0] is not checked for type=list[str]")
+        assert_that(
+            calling(engine.create_phrase).with_args(folder, "name",
+                "contents", hotkey=("<ctrl>", "a")),
+            not_(raises(ValueError)), "hotkey modifiers fails single valid str")
+        # assert_that(
+        #     calling(engine.create_phrase).with_args(folder, "name",
+        #         "contents", hotkey=(["<ctrl>", "<shift>"], "<alt>")),
+        #     raises(ValueError), "hotkey key is allowed to be a modifier")
 
 
 def test_engine_create_phrase_adds_phrase_to_parent():

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -220,6 +220,15 @@ def test_macro_expansion(test_input, expected, error_msg):
     assert_that(expandMacro(engine, test_input), is_(equal_to(expected)),
             error_msg)
 
+def test_system_macro():
+    engine, folder = create_engine()
+    home=os.environ['HOME']
+    test="one<system command='echo $HOME'>two"
+    expected="one{}two".format(home)
+    assert_that(expandMacro(engine, test), is_(equal_to(expected)),
+                "system macro fails")
+
+
 # def test_nested_macro_raises_error():
 #     contents="<date format=<cursor>>"
 #     # TODO


### PR DESCRIPTION
Runs system commands and replaces with the stdout.

This will add a huge amount of flexibility to phrase substitution, since
users can now replace a phrase with an arbitrary script's output.