### PR TITLE
Refactor the logging system, Closes #338

### DIFF
--- a/lib/autokey/argument_parser.py
+++ b/lib/autokey/argument_parser.py
@@ -15,11 +15,26 @@
 
 
 import argparse
+from typing import NamedTuple
 
 import autokey.common
 
+__all__ = [
+    "Namespace",
+    "parse_args"
+]
 
-def generate_argument_parser() -> argparse.ArgumentParser:
+Namespace = NamedTuple("Namespace", [
+    # Mock Namespace that mimics the object returned by parse_args() and should have the same signature.
+    # Used to provide better static type checking inside the IDE. Can also be used for unit testing.
+    # TODO: Convert to a class when the minimum Python version is risen to >= 3.6.
+    ("verbose", bool),
+    ("configure", bool),
+    ("cutelog_integration", bool),
+])
+
+
+def _generate_argument_parser() -> argparse.ArgumentParser:
     """Generates an ArgumentParser for AutoKey"""
     parser = argparse.ArgumentParser(description="Desktop automation ")
     parser.add_argument(
@@ -39,15 +54,20 @@ def generate_argument_parser() -> argparse.ArgumentParser:
         action="version",
         version="%(prog)s Version {}".format(autokey.common.VERSION)
     )
+    parser.add_argument(
+        "--cutelog-integration",
+        action="store_true",
+        help="Connect to a locally running cutelog instance with default settings to display the full program log. "
+             "See https://github.com/busimus/cutelog"
+    )
     return parser
 
 
-def parse_args():
+def parse_args() -> Namespace:
     """
-    Parses the command line arguments
+    Parses the command line arguments.
     :return: argparse Namespace object containing the parsed command line arguments
     """
-    parser = generate_argument_parser()
+    parser = _generate_argument_parser()
     args = parser.parse_args()
     return args
-

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -32,11 +32,6 @@ DATA_DIR = os.path.join(XDG_DATA_HOME, "autokey")
 AUTOSTART_DIR = os.path.join(XDG_CONFIG_HOME, "autostart")
 
 LOCK_FILE = os.path.join(RUN_DIR, "autokey.pid")
-LOG_FILE = os.path.join(DATA_DIR, "autokey.log")
-
-MAX_LOG_SIZE = 5 * 1024 * 1024  # 5 megabytes
-MAX_LOG_COUNT = 3
-LOG_FORMAT = "%(asctime)s %(levelname)s - %(name)s - %(message)s"
 
 APP_NAME = "autokey"
 CATALOG = ""

--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -17,8 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import dbus.service
-import logging
 
 XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
 # Runtime dir falls back to cache dir, as a fallback is suggested by the spec
@@ -54,28 +52,3 @@ ICON_FILE_NOTIFICATION_DARK = "autokey-status-dark"
 ICON_FILE_NOTIFICATION_ERROR = "autokey-status-error"
 
 USING_QT = False
-
-
-class AppService(dbus.service.Object):
-
-    def __init__(self, app):
-        busName = dbus.service.BusName('org.autokey.Service', bus=dbus.SessionBus())
-        dbus.service.Object.__init__(self, busName, "/AppService")
-        self.app = app
-        logging.debug("Created DBus service")
-
-    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='', out_signature='')
-    def show_configure(self):
-        self.app.show_configure()
-
-    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='s', out_signature='')
-    def run_script(self, name):
-        self.app.service.run_script(name)
-
-    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='s', out_signature='')
-    def run_phrase(self, name):
-        self.app.service.run_phrase(name)
-
-    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='s', out_signature='')
-    def run_folder(self, name):
-        self.app.service.run_folder(name)

--- a/lib/autokey/configmanager/configmanager.py
+++ b/lib/autokey/configmanager/configmanager.py
@@ -19,11 +19,11 @@
 import os
 import os.path
 import shutil
-import logging
 import glob
 import threading
 import typing
 import re
+import json
 
 from autokey import common, model
 from autokey.configmanager.configmanager_constants import CONFIG_FILE, CONFIG_DEFAULT_FOLDER, CONFIG_FILE_BACKUP, \
@@ -35,11 +35,10 @@ import autokey.configmanager.version_upgrading
 import autokey.configmanager.predefined_user_files
 from autokey.iomediator.constants import X_RECORD_INTERFACE, MODIFIERS
 from autokey.iomediator import key
+from autokey.logger import get_logger
 
-
-import json
-
-_logger = logging.getLogger("config-manager")
+logger = get_logger(__name__)
+del get_logger
 
 
 def create_config_manager_instance(auto_key_app, had_error=False):
@@ -49,33 +48,33 @@ def create_config_manager_instance(auto_key_app, had_error=False):
         config_manager = ConfigManager(auto_key_app)
     except Exception as e:
         if had_error or not os.path.exists(CONFIG_FILE_BACKUP) or not os.path.exists(CONFIG_FILE):
-            _logger.exception("Error while loading configuration. Cannot recover.")
+            logger.exception("Error while loading configuration. Cannot recover.")
             raise
 
-        _logger.exception("Error while loading configuration. Backup has been restored.")
+        logger.exception("Error while loading configuration. Backup has been restored.")
         os.remove(CONFIG_FILE)
         shutil.copy2(CONFIG_FILE_BACKUP, CONFIG_FILE)
         return create_config_manager_instance(auto_key_app, True)
 
-    _logger.debug("Global settings: %r", ConfigManager.SETTINGS)
+    logger.debug("Global settings: %r", ConfigManager.SETTINGS)
     return config_manager
 
 
 def save_config(config_manager):
-    _logger.info("Persisting configuration")
+    logger.info("Persisting configuration")
     config_manager.app.monitor.suspend()
     # Back up configuration if it exists
     # TODO: maybe use with-statement instead of try-except?
     if os.path.exists(CONFIG_FILE):
-        _logger.info("Backing up existing config file")
+        logger.info("Backing up existing config file")
         shutil.copy2(CONFIG_FILE, CONFIG_FILE_BACKUP)
     try:
         _persist_settings(config_manager)
-        _logger.info("Finished persisting configuration - no errors")
+        logger.info("Finished persisting configuration - no errors")
     except Exception as e:
         if os.path.exists(CONFIG_FILE_BACKUP):
             shutil.copy2(CONFIG_FILE_BACKUP, CONFIG_FILE)
-        _logger.exception("Error while saving configuration. Backup has been restored (if found).")
+        logger.exception("Error while saving configuration. Backup has been restored (if found).")
         raise Exception("Error while saving configuration. Backup has been restored (if found).")
     finally:
         config_manager.app.monitor.unsuspend()
@@ -116,7 +115,7 @@ def _remove_non_serializable_store_entries(store: dict):
     removed_key_list = []
     for key, value in store.items():
         if not (_is_serializable(key) and _is_serializable(value)):
-            _logger.info("Remove non-serializable item from the global script store. Key: '{}', Value: '{}'. "
+            logger.info("Remove non-serializable item from the global script store. Key: '{}', Value: '{}'. "
                          "This item cannot be saved and therefore will be lost.".format(key, value))
             removed_key_list.append(key)
     for key in removed_key_list:
@@ -217,10 +216,10 @@ class ConfigManager:
 
         # --- Code below here only executed if no persisted config data provided
 
-        _logger.info("No configuration found - creating new one")
+        logger.info("No configuration found - creating new one")
         self.folders.append(autokey.configmanager.predefined_user_files.create_my_phrases_folder())
         self.folders.append(autokey.configmanager.predefined_user_files.create_sample_scripts_folder())
-        _logger.debug("Initial folders generated and populated with example data.")
+        logger.debug("Initial folders generated and populated with example data.")
 
         # TODO - future functionality
         self.recentEntries = []
@@ -245,7 +244,7 @@ class ConfigManager:
 
     def load_global_config(self):
         if os.path.exists(CONFIG_FILE):
-            _logger.info("Loading config from existing file: " + CONFIG_FILE)
+            logger.info("Loading config from existing file: " + CONFIG_FILE)
 
             with open(CONFIG_FILE, 'r') as pFile:
                 data = json.load(pFile)
@@ -263,7 +262,7 @@ class ConfigManager:
 
             for entryPath in glob.glob(CONFIG_DEFAULT_FOLDER + "/*"):
                 if os.path.isdir(entryPath):
-                    _logger.debug("Loading folder at '%s'", entryPath)
+                    logger.debug("Loading folder at '%s'", entryPath)
                     f = model.Folder("", path=entryPath)
                     f.load(None)
                     self.folders.append(f)
@@ -280,7 +279,7 @@ class ConfigManager:
                 self.upgrade()
 
             self.config_altered(False)
-            _logger.info("Successfully loaded configuration")
+            logger.info("Successfully loaded configuration")
 
     def __checkExisting(self, path):
         # Check if we already know about the path, and return object if found
@@ -359,7 +358,7 @@ class ConfigManager:
                             loaded = True
 
             if not loaded:
-                _logger.warning("No action taken for create/update event at %s", path)
+                logger.warning("No action taken for create/update event at %s", path)
             else:
                 self.config_altered(False)
             return loaded
@@ -387,7 +386,7 @@ class ConfigManager:
             deleted = True
 
         if not deleted:
-            _logger.warning("No action taken for delete event at %s", path)
+            logger.warning("No action taken for delete event at %s", path)
         else:
             self.config_altered(False)
         return deleted
@@ -402,13 +401,13 @@ class ConfigManager:
         try:
             self.SETTINGS[DISABLED_MODIFIERS] = [key.Key(value) for value in self.SETTINGS[DISABLED_MODIFIERS]]
         except ValueError:
-            _logger.error("Unknown value in the disabled modifier list found. Unexpected: {}".format(
+            logger.error("Unknown value in the disabled modifier list found. Unexpected: {}".format(
                 self.SETTINGS[DISABLED_MODIFIERS]))
             self.SETTINGS[DISABLED_MODIFIERS] = []
 
         for possible_modifier in self.SETTINGS[DISABLED_MODIFIERS]:
             self._check_if_modifier(possible_modifier)
-            _logger.info("Disabling modifier key {} based on the stored configuration file.".format(possible_modifier))
+            logger.info("Disabling modifier key {} based on the stored configuration file.".format(possible_modifier))
             MODIFIERS.remove(possible_modifier)
 
     @staticmethod
@@ -429,10 +428,10 @@ class ConfigManager:
             modifier = key.Key(modifier)
         ConfigManager._check_if_modifier(modifier)
         try:
-            _logger.info("Disabling modifier key {} on user request.".format(modifier))
+            logger.info("Disabling modifier key {} on user request.".format(modifier))
             MODIFIERS.remove(modifier)
         except ValueError:
-            _logger.warning("Disabling already disabled modifier key. Affected key: {}".format(modifier))
+            logger.warning("Disabling already disabled modifier key. Affected key: {}".format(modifier))
         else:
             ConfigManager.SETTINGS[DISABLED_MODIFIERS].append(modifier)
 
@@ -447,11 +446,11 @@ class ConfigManager:
             modifier = key.Key(modifier)
         ConfigManager._check_if_modifier(modifier)
         if modifier not in MODIFIERS:
-            _logger.info("Re-eabling modifier key {} on user request.".format(modifier))
+            logger.info("Re-eabling modifier key {} on user request.".format(modifier))
             MODIFIERS.append(modifier)
             ConfigManager.SETTINGS[DISABLED_MODIFIERS].remove(modifier)
         else:
-            _logger.warning("Enabling already enabled modifier key. Affected key: {}".format(modifier))
+            logger.warning("Enabling already enabled modifier key. Affected key: {}".format(modifier))
 
     @staticmethod
     def _check_if_modifier(modifier: key.Key):
@@ -462,7 +461,7 @@ class ConfigManager:
                 modifier, key._ALL_MODIFIERS_))
 
     def reload_global_config(self):
-        _logger.info("Reloading global configuration")
+        logger.info("Reloading global configuration")
         with open(CONFIG_FILE, 'r') as pFile:
             data = json.load(pFile)
 
@@ -485,17 +484,17 @@ class ConfigManager:
         self.configHotkey.load_from_serialized(data["configHotkey"])
 
         self.config_altered(False)
-        _logger.info("Successfully reloaded global configuration")
+        logger.info("Successfully reloaded global configuration")
 
     def upgrade(self):
-        _logger.info("Checking if upgrade is needed from version %s", self.VERSION)
+        logger.info("Checking if upgrade is needed from version %s", self.VERSION)
 
         # Always reset interface type when upgrading
         self.SETTINGS[INTERFACE_TYPE] = X_RECORD_INTERFACE
-        _logger.info("Resetting interface type, new type: %s", self.SETTINGS[INTERFACE_TYPE])
+        logger.info("Resetting interface type, new type: %s", self.SETTINGS[INTERFACE_TYPE])
 
         if self.VERSION < '0.70.0':
-            _logger.info("Doing upgrade to 0.70.0")
+            logger.info("Doing upgrade to 0.70.0")
             for item in self.allItems:
                 if isinstance(item, model.Phrase):
                     item.sendMode = model.SendMode.KEYBOARD
@@ -515,7 +514,7 @@ class ConfigManager:
 
         @param persistGlobal: save the global configuration at the end of the process
         """
-        _logger.info("Configuration changed - rebuilding in-memory structures")
+        logger.info("Configuration changed - rebuilding in-memory structures")
 
         self.lock.acquire()
         # Rebuild root folder list
@@ -751,7 +750,7 @@ class GlobalHotkey(model.AbstractHotkey):
     def check_hotkey(self, modifiers, key, windowTitle):
         # TODO: Doesn’t this always return False? (as long as no exceptions are thrown)
         if model.AbstractHotkey.check_hotkey(self, modifiers, key, windowTitle) and self.enabled:
-            _logger.debug("Triggered global hotkey using modifiers: %r key: %r", modifiers, key)
+            logger.debug("Triggered global hotkey using modifiers: %r key: %r", modifiers, key)
             self.closure()
         return False
 

--- a/lib/autokey/configmanager/configmanager.py
+++ b/lib/autokey/configmanager/configmanager.py
@@ -35,10 +35,8 @@ import autokey.configmanager.version_upgrading
 import autokey.configmanager.predefined_user_files
 from autokey.iomediator.constants import X_RECORD_INTERFACE, MODIFIERS
 from autokey.iomediator import key
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 def create_config_manager_instance(auto_key_app, had_error=False):

--- a/lib/autokey/configmanager/predefined_user_files.py
+++ b/lib/autokey/configmanager/predefined_user_files.py
@@ -20,13 +20,14 @@ Script content is stored as Python files inside the predefined_user_scripts dire
 This eases maintenance of predefined user scripts, because those are not stored inside string variables any more.
 """
 
-import logging
 from typing import NamedTuple, List, Optional
 import pathlib
 
 from autokey.model import Folder, Script, Phrase, TriggerMode
+from autokey.logger import get_logger
 
-_logger = logging.getLogger("config-manager").getChild("sample-data_generation")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 # A Hotkey is defined by a list of modifier keys and a printable key.
 HotkeyData = NamedTuple("HotkeyData", [("modifiers", List[str]), ("key", str)])
@@ -141,7 +142,7 @@ def _create_script(data: ItemData, parent: Folder) -> Script:
     """
     content_path = pathlib.Path(__file__).parent / "predefined_user_scripts" / (data.content + ".pyi")
 
-    _logger.debug("Creating Script: name={}, path_to_content={}".format(data.name, content_path))
+    logger.debug("Creating Script: name={}, path_to_content={}".format(data.name, content_path))
 
     with open(str(content_path), "r", encoding="utf-8") as source_file:
         source_code = source_file.read()
@@ -161,7 +162,7 @@ def _create_script(data: ItemData, parent: Folder) -> Script:
 
 def _create_phrase(data: ItemData, parent: Folder) -> Phrase:
     """Create a Phrase from data. Place it into the parent folder."""
-    _logger.debug("Creating Phrase: name={}".format(data.name))
+    logger.debug("Creating Phrase: name={}".format(data.name))
     item = Phrase(data.name, data.content)
     if data.hotkey:
         item.set_hotkey(*data.hotkey)
@@ -178,7 +179,7 @@ def _create_phrase(data: ItemData, parent: Folder) -> Phrase:
 
 def _create_folder(name: str, parent: Folder=None) -> Folder:
     """Creates a folder with the given name. If parent is given, create it inside parent."""
-    _logger.info("About to create folder '{}'".format(name))
+    logger.info("About to create folder '{}'".format(name))
     folder = Folder(name)
     if parent is not None:
         parent.add_folder(folder)

--- a/lib/autokey/configmanager/predefined_user_files.py
+++ b/lib/autokey/configmanager/predefined_user_files.py
@@ -24,11 +24,8 @@ from typing import NamedTuple, List, Optional
 import pathlib
 
 from autokey.model import Folder, Script, Phrase, TriggerMode
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 # A Hotkey is defined by a list of modifier keys and a printable key.
 HotkeyData = NamedTuple("HotkeyData", [("modifiers", List[str]), ("key", str)])
 # ItemData holds everything needed to define a standalone Script or Phrase. For Scripts, content contains the file name

--- a/lib/autokey/configmanager/version_upgrading.py
+++ b/lib/autokey/configmanager/version_upgrading.py
@@ -35,13 +35,14 @@ happen with LTS distribution releases that skip several autokey versions during 
 """
 
 import os
-import logging
 from pathlib import Path
 
 from autokey import common, model
 import autokey.configmanager.configmanager_constants as cm_constants
+from autokey.logger import get_logger
 
-_logger = logging.getLogger("config-manager").getChild("version_upgrade")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 
 def upgrade_configuration(configuration_manager, config_data: dict):
@@ -59,7 +60,7 @@ def convert_v0_70_to_v0_80(config_data, old_version: str):
     try:
         _convert_v0_70_to_v0_80(config_data, old_version)
     except Exception:
-        _logger.exception(
+        logger.exception(
             "Problem occurred during conversion. "
             "Existing config file has been saved as {}{}".format(cm_constants.CONFIG_FILE, old_version)
         )
@@ -68,7 +69,7 @@ def convert_v0_70_to_v0_80(config_data, old_version: str):
 
 def _convert_v0_70_to_v0_80(config_data, old_version: str):
     os.rename(cm_constants.CONFIG_FILE, cm_constants.CONFIG_FILE + old_version)
-    _logger.info("Converting v{} configuration data to v0.80.0".format(old_version))
+    logger.info("Converting v{} configuration data to v0.80.0".format(old_version))
     for folder_data in config_data["folders"]:
         _convert_v0_70_to_v0_80_folder(folder_data, None)
 
@@ -79,7 +80,7 @@ def _convert_v0_70_to_v0_80(config_data, old_version: str):
     if os.path.exists(cm_constants.CONFIG_FILE_BACKUP):
         os.remove(cm_constants.CONFIG_FILE_BACKUP)
 
-    _logger.info("Conversion succeeded")
+    logger.info("Conversion succeeded")
 
 
 def _convert_v0_70_to_v0_80_folder(folder_data, parent):
@@ -119,7 +120,7 @@ def convert_autostart_entries_for_v0_95_3():
     old_autostart_file = Path(common.AUTOSTART_DIR) / "autokey-gtk.desktop"
     if old_autostart_file.exists():
         new_file_name = Path(common.AUTOSTART_DIR) / "autokey.desktop"
-        _logger.info("Found old autostart entry: '{}'. Rename to: '{}'".format(
+        logger.info("Found old autostart entry: '{}'. Rename to: '{}'".format(
             old_autostart_file, new_file_name)
         )
         old_autostart_file.rename(new_file_name)

--- a/lib/autokey/configmanager/version_upgrading.py
+++ b/lib/autokey/configmanager/version_upgrading.py
@@ -39,10 +39,8 @@ from pathlib import Path
 
 from autokey import common, model
 import autokey.configmanager.configmanager_constants as cm_constants
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 def upgrade_configuration(configuration_manager, config_data: dict):

--- a/lib/autokey/dbus_service.py
+++ b/lib/autokey/dbus_service.py
@@ -1,0 +1,34 @@
+import dbus.service
+
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
+
+
+class AppService(dbus.service.Object):
+    """
+    This class is used by the GTK GUI and provides the DBus interface.
+    It can be used by external programs to communicate with the autokey process.
+    """
+    def __init__(self, app):
+        busName = dbus.service.BusName('org.autokey.Service', bus=dbus.SessionBus())
+        dbus.service.Object.__init__(self, busName, "/AppService")
+        self.app = app
+        logger.debug("Created DBus service")
+
+    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='', out_signature='')
+    def show_configure(self):
+        self.app.show_configure()
+
+    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='s', out_signature='')
+    def run_script(self, name):
+        self.app.service.run_script(name)
+
+    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='s', out_signature='')
+    def run_phrase(self, name):
+        self.app.service.run_phrase(name)
+
+    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='s', out_signature='')
+    def run_folder(self, name):
+        self.app.service.run_folder(name)

--- a/lib/autokey/dbus_service.py
+++ b/lib/autokey/dbus_service.py
@@ -1,9 +1,22 @@
+# Copyright (C) 2011 Chris Dekter
+# Copyright (C) 2019 Thomas Hess <thomas.hess@udo.edu>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 import dbus.service
 
-from autokey.logger import get_logger
-
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 class AppService(dbus.service.Object):

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import autokey.dbus_service
 from . import common
 common.USING_QT = False
 
@@ -140,7 +141,7 @@ class Application:
         self.monitor.start()
 
         dbus.mainloop.glib.DBusGMainLoop(set_as_default=True)
-        self.dbusService = common.AppService(self)
+        self.dbusService = autokey.dbus_service.AppService(self)
 
         if configure:
             self.show_configure()

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -52,10 +52,8 @@ CONFIG_WINDOW_TITLE = "AutoKey"
 
 UI_DESCRIPTION_FILE = os.path.join(os.path.dirname(__file__), "data/menus.xml")
 
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 PROBLEM_MSG_PRIMARY = _("Some problems were found")
 PROBLEM_MSG_SECONDARY = _("%s\n\nYour changes have not been saved.")

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import locale
-import logging
 import os
 import threading
 import time
@@ -53,7 +52,10 @@ CONFIG_WINDOW_TITLE = "AutoKey"
 
 UI_DESCRIPTION_FILE = os.path.join(os.path.dirname(__file__), "data/menus.xml")
 
-_logger = logging.getLogger("configwindow")
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 PROBLEM_MSG_PRIMARY = _("Some problems were found")
 PROBLEM_MSG_SECONDARY = _("%s\n\nYour changes have not been saved.")

--- a/lib/autokey/gtkui/popupmenu.py
+++ b/lib/autokey/gtkui/popupmenu.py
@@ -21,11 +21,8 @@ from gi.repository import Gtk, Gdk
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
 
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 class PopupMenu(Gtk.Menu):
     """

--- a/lib/autokey/gtkui/popupmenu.py
+++ b/lib/autokey/gtkui/popupmenu.py
@@ -15,13 +15,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time, logging
+import time
 from gi.repository import Gtk, Gdk
 
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
 
-_logger = logging.getLogger("phrase-menu")
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
+
 
 class PopupMenu(Gtk.Menu):
     """
@@ -39,19 +43,19 @@ class PopupMenu(Gtk.Menu):
         self.service = service
         
         if cm.ConfigManager.SETTINGS[cm_constants.SORT_BY_USAGE_COUNT]:
-            _logger.debug("Sorting phrase menu by usage count")
+            logger.debug("Sorting phrase menu by usage count")
             folders.sort(key=lambda obj: obj.usageCount, reverse=True)
             items.sort(key=lambda obj: obj.usageCount, reverse=True)
         else:
-            _logger.debug("Sorting phrase menu by item name/title")
+            logger.debug("Sorting phrase menu by item name/title")
             folders.sort(key=lambda obj: str(obj))
             items.sort(key=lambda obj: str(obj))      
         
         if cm.ConfigManager.SETTINGS[cm_constants.TRIGGER_BY_INITIAL]:
-            _logger.debug("Triggering menu item by first initial")
+            logger.debug("Triggering menu item by first initial")
             self.triggerInitial = 1
         else:
-            _logger.debug("Triggering menu item by position in list")
+            logger.debug("Triggering menu item by position in list")
             self.triggerInitial = 0
 
 

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -18,10 +18,10 @@
 __all__ = ["XRecordInterface", "AtSpiInterface"]
 
 from abc import abstractmethod
+import logging
 import typing
 import threading
 import select
-import logging
 import queue
 import subprocess
 import time
@@ -73,8 +73,10 @@ except ImportError:
     
 from Xlib.protocol import rq, event
 
+from autokey.logger import get_logger
 
-logger = logging.getLogger("interface")
+logger = get_logger(__name__)
+del get_logger
 
 MASK_INDEXES = [
                (X.ShiftMapIndex, X.ShiftMask),
@@ -319,7 +321,7 @@ class XInterfaceBase(threading.Thread):
         self.__availableKeycodes = avail
         self.remappedChars = {}
 
-        if logging.getLogger().getEffectiveLevel() == logging.DEBUG:
+        if logger.getEffectiveLevel() == logging.DEBUG:
             self.keymap_test()
 
     def keymap_test(self):

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -73,11 +73,8 @@ except ImportError:
     
 from Xlib.protocol import rq, event
 
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 MASK_INDEXES = [
                (X.ShiftMapIndex, X.ShiftMask),
                (X.ControlMapIndex, X.ControlMask),

--- a/lib/autokey/iomediator/_iomediator.py
+++ b/lib/autokey/iomediator/_iomediator.py
@@ -1,6 +1,5 @@
 import threading
 import queue
-import logging
 
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
@@ -11,7 +10,10 @@ from .key import Key
 from .constants import X_RECORD_INTERFACE, KEY_SPLIT_RE, MODIFIERS, HELD_MODIFIERS
 
 CURRENT_INTERFACE = None
-_logger = logging.getLogger("iomediator")
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 
 class IoMediator(threading.Thread):
@@ -53,27 +55,27 @@ class IoMediator(threading.Thread):
 
         global CURRENT_INTERFACE
         CURRENT_INTERFACE = self.interface
-        _logger.info("Created IoMediator instance, current interface is: {}".format(CURRENT_INTERFACE))
+        logger.info("Created IoMediator instance, current interface is: {}".format(CURRENT_INTERFACE))
         
     def shutdown(self):
-        _logger.debug("IoMediator shutting down")
+        logger.debug("IoMediator shutting down")
         self.interface.cancel()
         self.queue.put_nowait((None, None))
-        _logger.debug("Waiting for IoMediator thread to end")
+        logger.debug("Waiting for IoMediator thread to end")
         self.join()
-        _logger.debug("IoMediator shutdown completed")
+        logger.debug("IoMediator shutdown completed")
 
     # Callback methods for Interfaces ----
 
     def set_modifier_state(self, modifier, state):
-        _logger.debug("Set modifier %s to %r", modifier, state)
+        logger.debug("Set modifier %s to %r", modifier, state)
         self.modifiers[modifier] = state
     
     def handle_modifier_down(self, modifier):
         """
         Updates the state of the given modifier key to 'pressed'
         """
-        _logger.debug("%s pressed", modifier)
+        logger.debug("%s pressed", modifier)
         if modifier in (Key.CAPSLOCK, Key.NUMLOCK):
             if self.modifiers[modifier]:
                 self.modifiers[modifier] = False
@@ -86,7 +88,7 @@ class IoMediator(threading.Thread):
         """
         Updates the state of the given modifier key to 'released'.
         """
-        _logger.debug("%s released", modifier)
+        logger.debug("%s released", modifier)
         # Caps and num lock are handled on key down only
         if modifier not in (Key.CAPSLOCK, Key.NUMLOCK):
             self.modifiers[modifier] = False
@@ -131,7 +133,7 @@ class IoMediator(threading.Thread):
         string = string.replace('\n', "<enter>")
         string = string.replace('\t', "<tab>")
         
-        _logger.debug("Send via event interface")
+        logger.debug("Send via event interface")
         self._clear_modifiers()
         modifiers = []
         for section in KEY_SPLIT_RE.split(string):
@@ -162,7 +164,7 @@ class IoMediator(threading.Thread):
         
     def paste_string(self, string, paste_command: SendMode):
         if len(string) > 0:
-            _logger.debug("Send via clipboard")
+            logger.debug("Send via clipboard")
             self.interface.send_string_clipboard(string, paste_command)
 
     def remove_string(self, string):

--- a/lib/autokey/iomediator/_iomediator.py
+++ b/lib/autokey/iomediator/_iomediator.py
@@ -10,10 +10,8 @@ from .key import Key
 from .constants import X_RECORD_INTERFACE, KEY_SPLIT_RE, MODIFIERS, HELD_MODIFIERS
 
 CURRENT_INTERFACE = None
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 class IoMediator(threading.Thread):

--- a/lib/autokey/logger.py
+++ b/lib/autokey/logger.py
@@ -15,13 +15,18 @@
 
 import logging
 import logging.handlers
+import pathlib
 import sys
 
 from autokey.argument_parser import Namespace
 import autokey.common
 
 root_logger = logging.getLogger(autokey.common.APP_NAME)
+
+MAX_LOG_SIZE = 5 * 1024 * 1024  # 5 megabytes
+MAX_LOG_COUNT = 3
 LOG_FORMAT = "%(asctime)s %(levelname)s - %(name)s - %(message)s"
+LOG_FILE = pathlib.Path(autokey.common.DATA_DIR) / "autokey.log"
 
 
 def get_logger(full_module_path: str) -> logging.Logger:
@@ -34,9 +39,9 @@ def configure_root_logger(args: Namespace):
     root_logger.setLevel(1)
 
     file_handler = logging.handlers.RotatingFileHandler(
-        autokey.common.LOG_FILE,
-        maxBytes=autokey.common.MAX_LOG_SIZE,
-        backupCount=autokey.common.MAX_LOG_COUNT
+        LOG_FILE,
+        maxBytes=MAX_LOG_SIZE,
+        backupCount=MAX_LOG_COUNT
     )
     file_handler.setLevel(logging.INFO)
 

--- a/lib/autokey/logger.py
+++ b/lib/autokey/logger.py
@@ -32,10 +32,20 @@ def get_logger(full_module_path: str) -> logging.Logger:
 def configure_root_logger(args: Namespace):
     """Initialise logging system"""
     root_logger.setLevel(1)
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(logging.DEBUG if args.verbose else logging.INFO)
-    handler.setFormatter(logging.Formatter(LOG_FORMAT))
-    root_logger.addHandler(handler)
+
+    file_handler = logging.handlers.RotatingFileHandler(
+        autokey.common.LOG_FILE,
+        maxBytes=autokey.common.MAX_LOG_SIZE,
+        backupCount=autokey.common.MAX_LOG_COUNT
+    )
+    file_handler.setLevel(logging.INFO)
+
+    stdout_stream_handler = logging.StreamHandler(sys.stdout)
+    stdout_stream_handler.setLevel(logging.DEBUG if args.verbose else logging.INFO)
+    stdout_stream_handler.setFormatter(logging.Formatter(LOG_FORMAT))
+
+    root_logger.addHandler(stdout_stream_handler)
+    root_logger.addHandler(file_handler)
     if args.cutelog_integration:
         socket_handler = logging.handlers.SocketHandler("127.0.0.1", 19996)  # default listening address
         root_logger.addHandler(socket_handler)

--- a/lib/autokey/logger.py
+++ b/lib/autokey/logger.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2018-2019 Thomas Hess <thomas.hess@udo.edu>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import logging.handlers
+import sys
+
+from autokey.argument_parser import Namespace
+import autokey.common
+
+root_logger = logging.getLogger(autokey.common.APP_NAME)
+LOG_FORMAT = "%(asctime)s %(levelname)s - %(name)s - %(message)s"
+
+
+def get_logger(full_module_path: str) -> logging.Logger:
+    module_path = ".".join(full_module_path.split(".")[1:])
+    return root_logger.getChild(module_path)
+
+
+def configure_root_logger(args: Namespace):
+    """Initialise logging system"""
+    root_logger.setLevel(1)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG if args.verbose else logging.INFO)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    root_logger.addHandler(handler)
+    if args.cutelog_integration:
+        socket_handler = logging.handlers.SocketHandler("127.0.0.1", 19996)  # default listening address
+        root_logger.addHandler(socket_handler)
+        root_logger.info(f"""Connected logger "{root_logger.name}" to local log server.""")

--- a/lib/autokey/logger.py
+++ b/lib/autokey/logger.py
@@ -19,14 +19,14 @@ import pathlib
 import sys
 
 from autokey.argument_parser import Namespace
-import autokey.common
+from autokey.common import APP_NAME, DATA_DIR
 
-root_logger = logging.getLogger(autokey.common.APP_NAME)
+root_logger = logging.getLogger(APP_NAME)
 
-MAX_LOG_SIZE = 5 * 1024 * 1024  # 5 megabytes
+MAX_LOG_SIZE = 5 * 2**20  # 5 megabytes
 MAX_LOG_COUNT = 3
 LOG_FORMAT = "%(asctime)s %(levelname)s - %(name)s - %(message)s"
-LOG_FILE = pathlib.Path(autokey.common.DATA_DIR) / "autokey.log"
+LOG_FILE = pathlib.Path(DATA_DIR) / "autokey.log"
 
 
 def get_logger(full_module_path: str) -> logging.Logger:

--- a/lib/autokey/model.py
+++ b/lib/autokey/model.py
@@ -20,7 +20,6 @@ import re
 import os
 import os.path
 import glob
-import logging
 import json
 import typing
 import enum
@@ -28,8 +27,10 @@ import enum
 import autokey.configmanager.configmanager_constants as cm_constants
 from autokey.iomediator.key import Key, NAVIGATION_KEYS
 from autokey.iomediator.constants import KEY_SPLIT_RE
+from autokey.logger import get_logger
 
-_logger = logging.getLogger("model")
+logger = get_logger(__name__)
+del get_logger
 
 DEFAULT_WORDCHAR_REGEX = '[\w]'
 
@@ -507,8 +508,8 @@ class Folder(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
                 data = json.load(inFile)
                 self.inject_json_data(data)
         except Exception:
-            _logger.exception("Error while loading json data for " + self.title)
-            _logger.error("JSON data not loaded (or loaded incomplete)")
+            logger.exception("Error while loading json data for " + self.title)
+            logger.error("JSON data not loaded (or loaded incomplete)")
 
     def inject_json_data(self, data):
         self.title = data["title"]
@@ -721,8 +722,8 @@ class Phrase(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
                 data = json.load(json_file)
                 self.inject_json_data(data)
         except Exception:
-            _logger.exception("Error while loading json data for " + self.description)
-            _logger.error("JSON data not loaded (or loaded incomplete)")
+            logger.exception("Error while loading json data for " + self.description)
+            logger.error("JSON data not loaded (or loaded incomplete)")
 
     def inject_json_data(self, data: dict):
         self.description = data["description"]
@@ -1071,7 +1072,7 @@ class Script(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
             if Script._is_serializable(key) and Script._is_serializable(value):
                 cleaned_store_data[key] = value
             else:
-                _logger.info("Skip non-serializable item in the local script store. Key: '{}', Value: '{}'. "
+                logger.info("Skip non-serializable item in the local script store. Key: '{}', Value: '{}'. "
                              "This item cannot be saved and therefore will be lost when autokey quits.".format(
                                 key, value
                 ))
@@ -1105,8 +1106,8 @@ class Script(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
                 data = json.load(jsonFile)
                 self.inject_json_data(data)
         except Exception:
-            _logger.exception("Error while loading json data for " + self.description)
-            _logger.error("JSON data not loaded (or loaded incomplete)")
+            logger.exception("Error while loading json data for " + self.description)
+            logger.error("JSON data not loaded (or loaded incomplete)")
 
     def inject_json_data(self, data: dict):
         self.description = data["description"]

--- a/lib/autokey/model.py
+++ b/lib/autokey/model.py
@@ -27,11 +27,8 @@ import enum
 import autokey.configmanager.configmanager_constants as cm_constants
 from autokey.iomediator.key import Key, NAVIGATION_KEYS
 from autokey.iomediator.constants import KEY_SPLIT_RE
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 DEFAULT_WORDCHAR_REGEX = '[\w]'
 
 JSON_FILE_PATTERN = "{}/.{}.json"

--- a/lib/autokey/monitor.py
+++ b/lib/autokey/monitor.py
@@ -17,16 +17,19 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import threading
-import logging
 import os.path
 import time
 
 from pyinotify import WatchManager, Notifier, EventsCodes, ProcessEvent
 
-_logger = logging.getLogger("inotify")
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 m = EventsCodes.OP_FLAGS
 MASK = m["IN_CREATE"]|m["IN_MODIFY"]|m["IN_DELETE"]|m["IN_MOVED_TO"]|m["IN_MOVED_FROM"]
+
 
 class Processor(ProcessEvent):
     
@@ -40,7 +43,7 @@ class Processor(ProcessEvent):
             path = os.path.join(event.path, event.name)
         else:
             path = event.path
-        _logger.debug("Reporting %s event at %s", event.maskname, path)
+        logger.debug("Reporting %s event at %s", event.maskname, path)
         return path
     
     def process_IN_MOVED_TO(self, event):
@@ -93,7 +96,7 @@ class FileMonitor(threading.Thread):
         self.__isSuspended = False
         for watch in self.watches:
             if not os.path.exists(watch):
-                _logger.debug("Removed stale watch on %s", watch)
+                logger.debug("Removed stale watch on %s", watch)
                 self.watches.remove(watch)
         
     def is_suspended(self):
@@ -103,12 +106,12 @@ class FileMonitor(threading.Thread):
         return path in self.watches
     
     def add_watch(self, path):
-        _logger.debug("Adding watch for %s", path)
+        logger.debug("Adding watch for %s", path)
         self.manager.add_watch(path, MASK, self.__p)
         self.watches.append(path)
         
     def remove_watch(self, path):
-        _logger.debug("Removing watch for %s", path)
+        logger.debug("Removing watch for %s", path)
         wd = self.manager.get_wd(path)
         self.manager.rm_watch(wd, True)
         self.watches.remove(path)
@@ -125,7 +128,7 @@ class FileMonitor(threading.Thread):
             if self.notifier.check_events(1000):
                 self.notifier.read_events()
         
-        _logger.info("Shutting down file monitor")
+        logger.info("Shutting down file monitor")
         self.notifier.stop()        
         
     def stop(self):

--- a/lib/autokey/monitor.py
+++ b/lib/autokey/monitor.py
@@ -22,11 +22,8 @@ import time
 
 from pyinotify import WatchManager, Notifier, EventsCodes, ProcessEvent
 
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 m = EventsCodes.OP_FLAGS
 MASK = m["IN_CREATE"]|m["IN_MODIFY"]|m["IN_DELETE"]|m["IN_MOVED_TO"]|m["IN_MOVED_FROM"]
 

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -19,8 +19,6 @@
 
 import sys
 import os.path
-import logging
-import logging.handlers
 import subprocess
 import queue
 import time
@@ -45,7 +43,9 @@ from autokey.qtui.notifier import Notifier
 from autokey.qtui.popupmenu import PopupMenu
 from autokey.qtui.configwindow import ConfigWindow
 from autokey.qtui.dbus_service import AppService
+from autokey.logger import get_logger, configure_root_logger
 
+logger = get_logger(__name__)
 
 AuthorData = NamedTuple("AuthorData", (("name", str), ("role", str), ("email", str)))
 AboutData = NamedTuple("AboutData", (
@@ -97,12 +97,12 @@ class Application(QApplication):
         self.args = autokey.argument_parser.parse_args()
         try:
             self._create_storage_directories()
-            self._configure_root_logger()
+            configure_root_logger(self.args)
         except Exception as e:
-            logging.exception("Fatal error starting AutoKey: " + str(e))
+            logger.exception("Fatal error starting AutoKey: " + str(e))
             self.show_error_dialog("Fatal error starting AutoKey.", str(e))
             sys.exit(1)
-        logging.info("Initialising application")
+        logger.info("Initialising application")
         self.setWindowIcon(QIcon.fromTheme(common.ICON_FILE, ui_common.load_icon(ui_common.AutoKeyIcon.AUTOKEY)))
         try:
 
@@ -122,9 +122,9 @@ class Application(QApplication):
             # Initialise user code dir
             if self.configManager.userCodeDir is not None:
                 sys.path.append(self.configManager.userCodeDir)
-            logging.debug("Creating DBus service")
+            logger.debug("Creating DBus service")
             self.dbus_service = AppService(self)
-            logging.debug("Service created")
+            logger.debug("Service created")
             self.show_configure_signal.connect(self.show_configure, Qt.QueuedConnection)
             if cm.ConfigManager.SETTINGS[cm_constants.IS_FIRST_RUN]:
                 cm.ConfigManager.SETTINGS[cm_constants.IS_FIRST_RUN] = False
@@ -135,7 +135,7 @@ class Application(QApplication):
             self.installEventFilter(KeyboardChangeFilter(self.service.mediator.interface))
 
         except Exception as e:
-            logging.exception("Fatal error starting AutoKey: " + str(e))
+            logger.exception("Fatal error starting AutoKey: " + str(e))
             self.show_error_dialog("Fatal error starting AutoKey.", str(e))
             sys.exit(1)
         else:
@@ -145,26 +145,10 @@ class Application(QApplication):
         try:
             self.service.start()
         except Exception as e:
-            logging.exception("Error starting interface: " + str(e))
+            logger.exception("Error starting interface: " + str(e))
             self.serviceDisabled = True
             self.show_error_dialog("Error starting interface. Keyboard monitoring will be disabled.\n" +
                                    "Check your system/configuration.", str(e))
-
-    def _configure_root_logger(self):
-        """Initialise logging system"""
-        root_logger = logging.getLogger()
-        root_logger.setLevel(logging.DEBUG)
-        if self.args.verbose:
-            handler = logging.StreamHandler(sys.stdout)
-        else:
-            handler = logging.handlers.RotatingFileHandler(
-                common.LOG_FILE,
-                maxBytes=common.MAX_LOG_SIZE,
-                backupCount=common.MAX_LOG_COUNT
-            )
-            handler.setLevel(logging.INFO)
-        handler.setFormatter(logging.Formatter(common.LOG_FORMAT))
-        root_logger.addHandler(handler)
 
     @staticmethod
     def _create_storage_directories():
@@ -192,14 +176,14 @@ class Application(QApplication):
                 # Check if the pid file contains garbage
                 int(pid)
             except ValueError:
-                logging.exception("AutoKey pid file contains garbage instead of a usable process id: " + pid)
+                logger.exception("AutoKey pid file contains garbage instead of a usable process id: " + pid)
                 sys.exit(1)
 
             # Check that the found PID is running and is autokey
             with subprocess.Popen(["ps", "-p", pid, "-o", "command"], stdout=subprocess.PIPE) as p:
                 output = p.communicate()[0].decode()
             if "autokey" in output:
-                logging.debug("AutoKey is already running as pid " + pid)
+                logger.debug("AutoKey is already running as pid " + pid)
                 bus = dbus.SessionBus()
 
                 try:
@@ -207,7 +191,7 @@ class Application(QApplication):
                     dbus_service.show_configure(dbus_interface="org.autokey.Service")
                     sys.exit(0)
                 except dbus.DBusException as e:
-                    logging.exception("Error communicating with Dbus service")
+                    logger.exception("Error communicating with Dbus service")
                     self.show_error_dialog(
                         message="AutoKey is already running as pid {} but is not responding".format(pid),
                         details=str(e))
@@ -216,7 +200,7 @@ class Application(QApplication):
         return True
 
     def init_global_hotkeys(self, configManager):
-        logging.info("Initialise global hotkeys")
+        logger.info("Initialise global hotkeys")
         configManager.toggleServiceHotkey.set_closure(self.toggle_service)
         configManager.configHotkey.set_closure(self.show_configure_signal.emit)
 
@@ -225,11 +209,11 @@ class Application(QApplication):
         self.notifier.create_assign_context_menu()
 
     def hotkey_created(self, item):
-        logging.debug("Created hotkey: %r %s", item.modifiers, item.hotKey)
+        logger.debug("Created hotkey: %r %s", item.modifiers, item.hotKey)
         self.service.mediator.interface.grab_hotkey(item)
 
     def hotkey_removed(self, item):
-        logging.debug("Removed hotkey: %r %s", item.modifiers, item.hotKey)
+        logger.debug("Removed hotkey: %r %s", item.modifiers, item.hotKey)
         self.service.mediator.interface.ungrab_hotkey(item)
 
     def path_created_or_modified(self, path):
@@ -270,14 +254,14 @@ class Application(QApplication):
         """
         Shut down the entire application.
         """
-        logging.info("Shutting down")
+        logger.info("Shutting down")
         self.closeAllWindows()
         self.notifier.hide()
         self.service.shutdown()
         self.monitor.stop()
         self.quit()
         os.remove(common.LOCK_FILE)  # TODO: maybe use atexit to remove the lock/pid file?
-        logging.debug("All shutdown tasks complete... quitting")
+        logger.debug("All shutdown tasks complete... quitting")
 
     def notify_error(self, message):
         """
@@ -294,7 +278,7 @@ class Application(QApplication):
         """
         Show the configuration window, or deiconify (un-minimise) it if it's already open.
         """
-        logging.info("Displaying configuration window")
+        logger.info("Displaying configuration window")
         self.configWindow.show()
         self.configWindow.showNormal()
         self.configWindow.activateWindow()
@@ -362,7 +346,7 @@ class CallbackEventHandler(QObject):
             try:
                 callback(*args)
             except Exception:
-                logging.exception("callback event failed: %r %r", callback, args, exc_info=True)
+                logger.exception("callback event failed: %r %r", callback, args, exc_info=True)
 
     def postEventWithCallback(self, callback, *args):
         self.queue.put((callback, args))

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -46,6 +46,7 @@ from autokey.qtui.dbus_service import AppService
 from autokey.logger import get_logger, configure_root_logger
 
 logger = get_logger(__name__)
+del get_logger
 
 AuthorData = NamedTuple("AuthorData", (("name", str), ("role", str), ("email", str)))
 AboutData = NamedTuple("AboutData", (

--- a/lib/autokey/qtui/centralwidget.py
+++ b/lib/autokey/qtui/centralwidget.py
@@ -13,7 +13,7 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-import os.path
+
 import logging
 import pathlib
 import typing
@@ -30,9 +30,10 @@ import autokey.configmanager.configmanager_constants as cm_constants
 
 from autokey.qtui import common as ui_common
 from autokey.qtui import autokey_treewidget as ak_tree
+from autokey.logger import get_logger, root_logger
 
-
-logger = ui_common.logger.getChild("CentralWidget")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 
 class CentralWidget(*ui_common.inherits_from_ui_file_with_name("centralwidget")):
@@ -529,7 +530,6 @@ class CentralWidget(*ui_common.inherits_from_ui_file_with_name("centralwidget"))
                         item_widgets.append(item_widget.child(child_index))
             raise RuntimeError("Expected item {} not found in the tree!".format(currently_edited_item))
 
-
     def get_selected_item(self):
         return self.__getSelection()
 
@@ -598,7 +598,6 @@ class ListWidgetHandler(logging.Handler):
         self.app = app
         self.level = logging.DEBUG
 
-        root_logger = logging.getLogger()
         log_format = "%(message)s"
         root_logger.addHandler(self)
         self.setFormatter(logging.Formatter(log_format))

--- a/lib/autokey/qtui/common.py
+++ b/lib/autokey/qtui/common.py
@@ -14,7 +14,6 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import re
-import logging
 import os.path
 import pathlib
 import enum
@@ -27,6 +26,7 @@ from PyQt5 import uic
 from PyQt5.QtSvg import QSvgRenderer
 
 import autokey.configmanager.configmanager_constants as cm_constants
+from autokey.logger import get_logger
 
 try:
     import autokey.qtui.compiled_resources
@@ -52,10 +52,9 @@ else:
     ICON_PATH_PREFIX = ":/icons"
     atexit.register(autokey.qtui.compiled_resources.qCleanupResources)
 
-
+logger = get_logger(__name__)
+del get_logger
 EMPTY_FIELD_REGEX = re.compile(r"^ *$", re.UNICODE)
-
-logger = logging.getLogger("root").getChild("Qt-GUI")  # type: logging.Logger
 
 
 def monospace_font() -> QFont:

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -30,11 +30,8 @@ import autokey.configmanager.configmanager_constants as cm_constants
 from autokey import model
 from .settings import SettingsDialog
 from . import dialogs
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 PROBLEM_MSG_PRIMARY = "Some problems were found"
 PROBLEM_MSG_SECONDARY = "%1\n\nYour changes have not been saved."
 

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-import logging
 import threading
 import time
 import webbrowser
@@ -32,11 +30,13 @@ import autokey.configmanager.configmanager_constants as cm_constants
 from autokey import model
 from .settings import SettingsDialog
 from . import dialogs
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 PROBLEM_MSG_PRIMARY = "Some problems were found"
 PROBLEM_MSG_SECONDARY = "%1\n\nYour changes have not been saved."
-
-_logger = autokey.qtui.common.logger.getChild("configwindow")  # type: logging.Logger
 
 
 class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwindow")):
@@ -225,7 +225,7 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
         self.action_redo.setEnabled(state)
 
     def save_completed(self, persist_global):
-        _logger.debug("Saving completed. persist_global: {}".format(persist_global))
+        logger.debug("Saving completed. persist_global: {}".format(persist_global))
         self.action_save.setEnabled(False)
         self.app.config_altered(persist_global)
         
@@ -247,7 +247,6 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
                 return False
 
         self.hide()
-        # logging.getLogger().removeHandler(self.central_widget.logHandler)
         return True
     
     # File Menu

--- a/lib/autokey/qtui/dialogs/abbrsettings.py
+++ b/lib/autokey/qtui/dialogs/abbrsettings.py
@@ -19,16 +19,16 @@ This module contains the abbreviation settings dialog and used components.
 This dialog allows the user to set and configure abbreviations to trigger scripts and phrases.
 """
 
-import logging
-
 from PyQt5 import QtCore
 from PyQt5.QtWidgets import QListWidgetItem, QDialogButtonBox
 
 from autokey.qtui import common as ui_common
 
 from autokey import model
+from autokey.logger import get_logger
 
-logger = ui_common.logger.getChild("Abbreviation Settings Dialog")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 WORD_CHAR_OPTIONS = {
                      "All non-word": model.DEFAULT_WORDCHAR_REGEX,

--- a/lib/autokey/qtui/dialogs/abbrsettings.py
+++ b/lib/autokey/qtui/dialogs/abbrsettings.py
@@ -25,11 +25,8 @@ from PyQt5.QtWidgets import QListWidgetItem, QDialogButtonBox
 from autokey.qtui import common as ui_common
 
 from autokey import model
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 WORD_CHAR_OPTIONS = {
                      "All non-word": model.DEFAULT_WORDCHAR_REGEX,
                      "Space and Enter": r"[^ \n]",

--- a/lib/autokey/qtui/dialogs/hotkeysettings.py
+++ b/lib/autokey/qtui/dialogs/hotkeysettings.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 import typing
 
 from PyQt5.QtCore import pyqtSignal
@@ -25,8 +24,10 @@ from autokey.qtui import common as ui_common
 from autokey import iomediator, model
 import autokey.configmanager.configmanager as cm
 from autokey.iomediator.key import Key
+from autokey.logger import get_logger
 
-logger = ui_common.logger.getChild("Hotkey Settings Dialog")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 Item = typing.Union[model.Folder, model.Script, model.Phrase]
 
 

--- a/lib/autokey/qtui/dialogs/hotkeysettings.py
+++ b/lib/autokey/qtui/dialogs/hotkeysettings.py
@@ -24,10 +24,8 @@ from autokey.qtui import common as ui_common
 from autokey import iomediator, model
 import autokey.configmanager.configmanager as cm
 from autokey.iomediator.key import Key
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 Item = typing.Union[model.Folder, model.Script, model.Phrase]
 
 

--- a/lib/autokey/qtui/dialogs/recorddialog.py
+++ b/lib/autokey/qtui/dialogs/recorddialog.py
@@ -16,11 +16,8 @@
 
 from autokey.qtui import common as ui_common
 
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 class RecordDialog(*ui_common.inherits_from_ui_file_with_name("record_dialog")):
 

--- a/lib/autokey/qtui/dialogs/recorddialog.py
+++ b/lib/autokey/qtui/dialogs/recorddialog.py
@@ -16,8 +16,10 @@
 
 from autokey.qtui import common as ui_common
 
-import logging
-logger = ui_common.logger.getChild("Record Dialog")  # type: logging.Logger
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 
 class RecordDialog(*ui_common.inherits_from_ui_file_with_name("record_dialog")):

--- a/lib/autokey/qtui/folderpage.py
+++ b/lib/autokey/qtui/folderpage.py
@@ -22,12 +22,10 @@ import autokey.configmanager.configmanager_constants as cm_constants
 import autokey.qtui.common as ui_common
 
 from autokey.model import Folder
+from autokey.logger import get_logger
 
-if typing.TYPE_CHECKING:
-    import logging
-
-
-logger = ui_common.logger.getChild("FolderPage")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 PROBLEM_MSG_PRIMARY = "Some problems were found"
 PROBLEM_MSG_SECONDARY = "{}\n\nYour changes have not been saved."

--- a/lib/autokey/qtui/folderpage.py
+++ b/lib/autokey/qtui/folderpage.py
@@ -22,11 +22,8 @@ import autokey.configmanager.configmanager_constants as cm_constants
 import autokey.qtui.common as ui_common
 
 from autokey.model import Folder
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 PROBLEM_MSG_PRIMARY = "Some problems were found"
 PROBLEM_MSG_SECONDARY = "{}\n\nYour changes have not been saved."
 

--- a/lib/autokey/qtui/notifier.py
+++ b/lib/autokey/qtui/notifier.py
@@ -23,14 +23,11 @@ from autokey.qtui import popupmenu
 import autokey.qtui.common as ui_common
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
-from autokey.logger import get_logger
-
-logger = get_logger(__name__)
-del get_logger
 
 if TYPE_CHECKING:
     from autokey.qtapp import Application
 
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 TOOLTIP_RUNNING = "AutoKey - running"
 TOOLTIP_PAUSED = "AutoKey - paused"
 

--- a/lib/autokey/qtui/notifier.py
+++ b/lib/autokey/qtui/notifier.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 from typing import Optional, Callable, TYPE_CHECKING
 
 from PyQt5.QtGui import QIcon
@@ -24,15 +23,16 @@ from autokey.qtui import popupmenu
 import autokey.qtui.common as ui_common
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
+from autokey.logger import get_logger
 
+logger = get_logger(__name__)
+del get_logger
 
 if TYPE_CHECKING:
     from autokey.qtapp import Application
 
 TOOLTIP_RUNNING = "AutoKey - running"
 TOOLTIP_PAUSED = "AutoKey - paused"
-
-logger = ui_common.logger.getChild("System-tray-notifier")  # type: logging.Logger
 
 
 class Notifier(QSystemTrayIcon):

--- a/lib/autokey/qtui/popupmenu.py
+++ b/lib/autokey/qtui/popupmenu.py
@@ -16,7 +16,6 @@
 
 from typing import List, Union
 
-import logging
 from PyQt5.QtCore import Qt, pyqtSignal
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QMenu, QAction, QWidget
@@ -26,10 +25,13 @@ import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
 import autokey.model
 import autokey.service
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 FolderList = List[autokey.model.Folder]
 Item = Union[autokey.model.Script, autokey.model.Phrase]
-_logger = logging.getLogger("phrase-menu")
 
 
 class PopupMenu(QMenu):
@@ -56,11 +58,11 @@ class PopupMenu(QMenu):
             self.setTitle(title)
         
         if cm.ConfigManager.SETTINGS[cm_constants.SORT_BY_USAGE_COUNT]:
-            _logger.debug("Sorting phrase menu by usage count")
+            logger.debug("Sorting phrase menu by usage count")
             folders.sort(key=lambda obj: obj.usageCount, reverse=True)
             items.sort(key=lambda obj: obj.usageCount, reverse=True)
         else:
-            _logger.debug("Sorting phrase menu by item name/title")
+            logger.debug("Sorting phrase menu by item name/title")
             folders.sort(key=lambda obj: str(obj))
             items.sort(key=lambda obj: str(obj))      
         
@@ -172,5 +174,5 @@ class ItemAction(QAction):
         else:
             error_msg = "ItemAction got unknown item. Expected Union[autokey.model.Script, autokey.model.Phrase], " \
                         "got '{}'".format(str(type(item)))
-            _logger.error(error_msg)
+            logger.error(error_msg)
             raise ValueError(error_msg)

--- a/lib/autokey/qtui/popupmenu.py
+++ b/lib/autokey/qtui/popupmenu.py
@@ -25,11 +25,8 @@ import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
 import autokey.model
 import autokey.service
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 FolderList = List[autokey.model.Folder]
 Item = Union[autokey.model.Script, autokey.model.Phrase]
 

--- a/lib/autokey/qtui/settings/engine.py
+++ b/lib/autokey/qtui/settings/engine.py
@@ -20,10 +20,7 @@ from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QFileDialog, QWidget, QApplication
 
 from autokey.qtui import common
-from autokey.logger import get_logger
-
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 class EngineSettings(*common.inherits_from_ui_file_with_name("enginesettings")):

--- a/lib/autokey/qtui/settings/engine.py
+++ b/lib/autokey/qtui/settings/engine.py
@@ -15,16 +15,15 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import sys
-import logging
-import typing
 
 from PyQt5.QtCore import pyqtSlot
 from PyQt5.QtWidgets import QFileDialog, QWidget, QApplication
 
 from autokey.qtui import common
+from autokey.logger import get_logger
 
-
-logger = common.logger.getChild("AutoKey configuration")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 
 class EngineSettings(*common.inherits_from_ui_file_with_name("enginesettings")):

--- a/lib/autokey/qtui/settings/general.py
+++ b/lib/autokey/qtui/settings/general.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import logging
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QWidget, QComboBox
@@ -29,8 +28,10 @@ from autokey.iomediator.key import Key
 
 import autokey.qtui.common as ui_common
 import autokey.common as common
+from autokey.logger import get_logger
 
-logger = ui_common.logger.getChild("General settings widget")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 
 class GeneralSettings(*ui_common.inherits_from_ui_file_with_name("generalsettings")):

--- a/lib/autokey/qtui/settings/general.py
+++ b/lib/autokey/qtui/settings/general.py
@@ -28,10 +28,8 @@ from autokey.iomediator.key import Key
 
 import autokey.qtui.common as ui_common
 import autokey.common as common
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 class GeneralSettings(*ui_common.inherits_from_ui_file_with_name("generalsettings")):

--- a/lib/autokey/qtui/settings/settingsdialog.py
+++ b/lib/autokey/qtui/settings/settingsdialog.py
@@ -13,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import logging
 from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import pyqtSlot
@@ -24,8 +23,10 @@ from autokey.qtui import common
 if TYPE_CHECKING:
     from autokey.qtapp import Application
 
+from autokey.logger import get_logger
 
-logger = common.logger.getChild("Settings Dialog")  # type: logging.Logger
+logger = get_logger(__name__)
+del get_logger
 
 
 class SettingsDialog(*common.inherits_from_ui_file_with_name("settingsdialog")):

--- a/lib/autokey/qtui/settings/settingsdialog.py
+++ b/lib/autokey/qtui/settings/settingsdialog.py
@@ -23,10 +23,8 @@ from autokey.qtui import common
 if TYPE_CHECKING:
     from autokey.qtapp import Application
 
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 class SettingsDialog(*common.inherits_from_ui_file_with_name("settingsdialog")):

--- a/lib/autokey/qtui/settings/specialhotkeys.py
+++ b/lib/autokey/qtui/settings/specialhotkeys.py
@@ -20,13 +20,13 @@ from PyQt5.QtWidgets import QDialog, QWidget, QApplication, QLabel, QPushButton
 
 from autokey.qtui.dialogs import GlobalHotkeyDialog
 import autokey.qtui.common as ui_common
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 if typing.TYPE_CHECKING:
-    import logging
-
     from autokey.qtapp import Application
-
-logger = ui_common.logger.getChild("Special Hotkey Settings widget")  # type: logging.Logger
 
 
 class SpecialHotkeySettings(*ui_common.inherits_from_ui_file_with_name("specialhotkeysettings")):

--- a/lib/autokey/qtui/settings/specialhotkeys.py
+++ b/lib/autokey/qtui/settings/specialhotkeys.py
@@ -20,13 +20,11 @@ from PyQt5.QtWidgets import QDialog, QWidget, QApplication, QLabel, QPushButton
 
 from autokey.qtui.dialogs import GlobalHotkeyDialog
 import autokey.qtui.common as ui_common
-from autokey.logger import get_logger
-
-logger = get_logger(__name__)
-del get_logger
-
 if typing.TYPE_CHECKING:
     from autokey.qtapp import Application
+
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 class SpecialHotkeySettings(*ui_common.inherits_from_ui_file_with_name("specialhotkeysettings")):

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -19,7 +19,6 @@
 import traceback
 import collections
 import time
-import logging
 import threading
 
 from autokey.iomediator.key import Key, KEY_FIND_RE
@@ -31,7 +30,10 @@ from autokey import model
 import autokey.scripting
 from autokey.configmanager.configmanager import ConfigManager, save_config
 import autokey.configmanager.configmanager_constants as cm_constants
-logger = logging.getLogger("service")
+from autokey.logger import get_logger
+
+logger = get_logger(__name__)
+del get_logger
 
 MAX_STACK_LENGTH = 150
 

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -30,11 +30,8 @@ from autokey import model
 import autokey.scripting
 from autokey.configmanager.configmanager import ConfigManager, save_config
 import autokey.configmanager.configmanager_constants as cm_constants
-from autokey.logger import get_logger
 
-logger = get_logger(__name__)
-del get_logger
-
+logger = __import__("autokey.logger").logger.get_logger(__name__)
 MAX_STACK_LENGTH = 150
 
 


### PR DESCRIPTION
- Closes #338 
- Always print INFO level and above to the standard output
- Use a hierarchical logging system to group messages by module/package
- Consistent usage of a new logging module across the project
- Creating a new logger for a module is easy, just put this line at the module top:
  ```python
  logger = __import__("autokey.logger").logger.get_logger(__name__)
  ```