### PR TITLE
Better script error handling

### DIFF
--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -36,7 +36,7 @@ from gi.repository import Gtk, Gdk, GObject, GLib
 gettext.install("autokey")
 
 import autokey.argument_parser
-from autokey import service, monitor
+from autokey import service, monitor, model
 from autokey.gtkui.notifier import get_notifier
 from autokey.gtkui.popupmenu import PopupMenu
 from autokey.gtkui.configwindow import ConfigWindow
@@ -226,12 +226,13 @@ class Application:
         os.remove(common.LOCK_FILE)
         logger.debug("All shutdown tasks complete... quitting")
 
-    def notify_error(self, message):
+    def notify_error(self, error: model.ScriptErrorRecord):
         """
         Show an error notification popup.
 
-        @param message: Message to show in the popup
+        @param error: The error that occurred in a Script
         """
+        message = "The script '{}' encountered an error".format(error.script_name)
         self.notifier.notify_error(message)
 
     def update_notifier_visibility(self):

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -40,6 +40,7 @@ from autokey import service, monitor, model
 from autokey.gtkui.notifier import get_notifier
 from autokey.gtkui.popupmenu import PopupMenu
 from autokey.gtkui.configwindow import ConfigWindow
+from autokey.gtkui.dialogs import ShowScriptErrorsDialog
 import autokey.configmanager.configmanager as cm
 import autokey.configmanager.configmanager_constants as cm_constants
 from autokey.logger import get_logger, configure_root_logger
@@ -275,21 +276,18 @@ class Application:
         """
         Show the last script error (if any)
         """
-        if self.service.scriptRunner.error != '':
-            dlg = Gtk.MessageDialog(type=Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.OK,
-                                     message_format=self.service.scriptRunner.error)
-            self.service.scriptRunner.error = ''
+        if self.service.scriptRunner.error_records:
+            dlg = ShowScriptErrorsDialog(self)
             # revert the tray icon
             self.notifier.set_icon(cm.ConfigManager.SETTINGS[cm_constants.NOTIFICATION_ICON])
             self.notifier.errorItem.hide()
             self.notifier.update_visible_status()
-
         else:
             dlg = Gtk.MessageDialog(type=Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.OK,
                                      message_format=_("No error information available"))
 
-        dlg.set_title(_("View script error"))
-        dlg.set_transient_for(parent)
+            dlg.set_title(_("View script error"))
+            dlg.set_transient_for(parent)
         dlg.run()
         dlg.destroy()
 

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -34,9 +34,6 @@ from gi.repository import Gtk, Pango, GtkSource, Gdk, Gio
 GETTEXT_DOMAIN = 'autokey'
 
 locale.setlocale(locale.LC_ALL, '')
-#for module in Gtk.glade, gettext:
-#    module.bindtextdomain(GETTEXT_DOMAIN)
-#    module.textdomain(GETTEXT_DOMAIN)
 
 
 from . import dialogs
@@ -59,11 +56,7 @@ PROBLEM_MSG_PRIMARY = _("Some problems were found")
 PROBLEM_MSG_SECONDARY = _("%s\n\nYour changes have not been saved.")
 
 from .configwindow0 import get_ui
-# def get_ui(fileName):
-#     builder = Gtk.Builder()
-#     uiFile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/" + fileName)
-#     builder.add_from_file(uiFile)
-#     return builder
+
 
 def set_linkbutton(button, path):
     button.set_sensitive(True)
@@ -313,6 +306,7 @@ class SettingsWidget:
         # Magic fudge to allow us to pretend to be the ui class we encapsulate
         return getattr(self.ui, attr)
 
+
 class BlankPage:
 
     def __init__(self, parentWindow):
@@ -340,6 +334,7 @@ class BlankPage:
 
     def set_dirty(self):
         self.parentWindow.set_dirty(True)
+
 
 class FolderPage:
 
@@ -743,7 +738,6 @@ class PhrasePage(ScriptPage):
         self.editor.set_sensitive(True)
 
 
-
 class ConfigWindow:
 
     def __init__(self, app):
@@ -786,8 +780,6 @@ class ConfigWindow:
             ("Tools", None, _("_Tools")),
             ("script-error", Gtk.STOCK_DIALOG_ERROR, _("Vie_w script error"), None, _("View script error information"), self.on_show_error),
             ("run", Gtk.STOCK_MEDIA_PLAY, _("_Run current script"), None, _("Run the currently selected script"), self.on_run_script),
-            #("Settings", None, _("_Settings"), None, None, None),
-            #("advanced", Gtk.STOCK_PREFERENCES, _("_Advanced Settings"), "", _("Advanced configuration options"), self.on_advanced_settings),
             ("Help", None, _("_Help")),
             ("faq", None, _("_F.A.Q."), None, _("Display Frequently Asked Questions"), self.on_show_faq),
             ("help", Gtk.STOCK_HELP, _("Online _Help"), None, _("Display Online Help"), self.on_show_help),
@@ -798,9 +790,9 @@ class ConfigWindow:
         actionGroup.add_actions(actions)
 
         toggleActions = [
-                         ("toolbar", None, _("_Show Toolbar"), None, _("Show/hide the toolbar"), self.on_toggle_toolbar),
-                         ("record", Gtk.STOCK_MEDIA_RECORD, _("R_ecord keyboard/mouse"), None, _("Record keyboard/mouse actions"), self.on_record_keystrokes),
-                         ]
+            ("toolbar", None, _("_Show Toolbar"), None, _("Show/hide the toolbar"), self.on_toggle_toolbar),
+            ("record", Gtk.STOCK_MEDIA_RECORD, _("R_ecord keyboard/mouse"), None, _("Record keyboard/mouse actions"), self.on_record_keystrokes),
+        ]
         actionGroup.add_toggle_actions(toggleActions)
 
         self.uiManager.insert_action_group(actionGroup, 0)
@@ -1673,4 +1665,3 @@ class AkTreeModel(Gtk.TreeStore):
             # return cmp(str(item1), str(item2))
             a, b = str(item1), str(item2)
             return (a > b) - (a < b)
-

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -1267,7 +1267,7 @@ close and reopen the AutoKey window.\nThis message is only shown once per sessio
     def __runScript(self):
         script = self.__getTreeSelection()[0]
         time.sleep(2)
-        self.app.service.scriptRunner.execute(script)
+        self.app.service.scriptRunner.execute_script(script)
 
     # Help Menu
 

--- a/lib/autokey/gtkui/configwindow0.py
+++ b/lib/autokey/gtkui/configwindow0.py
@@ -1,6 +1,7 @@
 import os
 from gi.repository import Gtk
 
+
 def get_ui(fileName):
     builder = Gtk.Builder()
     uiFile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data/" + fileName)

--- a/lib/autokey/gtkui/data/show_script_errors_dialog.xml
+++ b/lib/autokey/gtkui/data/show_script_errors_dialog.xml
@@ -10,6 +10,8 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Show recorded errors from Scripts</property>
     <property name="type_hint">dialog</property>
+    <property name="urgency_hint">True</property>
+    <property name="has_resize_grip">True</property>
     <child>
       <placeholder/>
     </child>
@@ -98,7 +100,7 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Currently showing error</property>
+                <property name="label" translatable="yes">Currently showing error: </property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -107,12 +109,10 @@
               </packing>
             </child>
             <child>
-              <object class="GtkSpinButton" id="current_error_spin_box">
+              <object class="GtkLabel" id="current_error_label">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="input_purpose">number</property>
-                <property name="numeric">True</property>
-                <property name="value">1</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">{}</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -124,12 +124,12 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">/</property>
+                <property name="label" translatable="yes"> / </property>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">3</property>
               </packing>
             </child>
             <child>
@@ -141,11 +141,20 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">3</property>
+                <property name="position">4</property>
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">5</property>
+              </packing>
             </child>
             <child>
               <object class="GtkButton" id="first_error_button">
@@ -160,7 +169,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">5</property>
+                <property name="position">6</property>
               </packing>
             </child>
             <child>
@@ -176,7 +185,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">6</property>
+                <property name="position">7</property>
               </packing>
             </child>
             <child>
@@ -192,7 +201,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">7</property>
+                <property name="position">8</property>
               </packing>
             </child>
             <child>
@@ -208,7 +217,7 @@
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">8</property>
+                <property name="position">9</property>
               </packing>
             </child>
           </object>
@@ -363,13 +372,22 @@
           </packing>
         </child>
         <child>
-          <object class="GtkTextView" id="crash_stack_trace_field">
+          <object class="GtkScrolledWindow">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
-            <property name="editable">False</property>
-            <property name="monospace">True</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkTextView" id="crash_stack_trace_field">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="editable">False</property>
+                <property name="monospace">True</property>
+              </object>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/lib/autokey/gtkui/data/show_script_errors_dialog.xml
+++ b/lib/autokey/gtkui/data/show_script_errors_dialog.xml
@@ -6,8 +6,9 @@
   <!-- interface-name AutoKey -->
   <!-- interface-copyright 2020 -->
   <!-- interface-authors Thomas Hess -->
-  <object class="GtkDialog">
+  <object class="GtkDialog" id="show_script_errors_dialog">
     <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Show recorded errors from Scripts</property>
     <property name="type_hint">dialog</property>
     <child>
       <placeholder/>
@@ -22,13 +23,14 @@
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="clear_all_errors_button">
                 <property name="label">gtk-clear</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="tooltip_text" translatable="yes">Clear the whole error list and close this window</property>
                 <property name="use_stock">True</property>
+                <signal name="clicked" handler="clear_all_errors" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -37,13 +39,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="delete_currently_shown_error_button">
                 <property name="label">gtk-delete</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="tooltip_text" translatable="yes">Delete the currently shown error record</property>
                 <property name="use_stock">True</property>
+                <signal name="clicked" handler="delete_currently_shown_error" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -52,7 +55,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="hide_button">
                 <property name="label">gtk-close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -60,6 +63,7 @@
                 <property name="tooltip_text" translatable="yes">Close this window, keeping all error records.</property>
                 <property name="use_stock">True</property>
                 <property name="always_show_image">True</property>
+                <signal name="clicked" handler="on_close" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -103,7 +107,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkSpinButton">
+              <object class="GtkSpinButton" id="current_error_spin_box">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="input_purpose">number</property>
@@ -129,7 +133,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
+              <object class="GtkLabel" id="total_error_count_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">{}</property>
@@ -144,13 +148,14 @@
               <placeholder/>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="first_error_button">
                 <property name="label">gtk-goto-first</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="tooltip_text" translatable="yes">Show the oldest recorded script error</property>
                 <property name="use_stock">True</property>
+                <signal name="clicked" handler="show_first_error" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -159,13 +164,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="previous_error_button">
                 <property name="label">gtk-go-back</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="tooltip_text" translatable="yes">Show the previous recorded script error</property>
                 <property name="use_stock">True</property>
+                <signal name="clicked" handler="show_previous_error" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -174,13 +180,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="next_error_button">
                 <property name="label">gtk-go-forward</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="tooltip_text" translatable="yes">Show the next recorded script error</property>
                 <property name="use_stock">True</property>
+                <signal name="clicked" handler="show_next_error" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -189,13 +196,14 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkButton" id="last_error_button">
                 <property name="label">gtk-goto-last</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="tooltip_text" translatable="yes">Show the newest recorded script error</property>
                 <property name="use_stock">True</property>
+                <signal name="clicked" handler="show_last_error" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -275,7 +283,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkTextView">
+              <object class="GtkTextView" id="script_name_field">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="tooltip_text" translatable="yes">The name of the failed Script.</property>
@@ -290,7 +298,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkTextView">
+              <object class="GtkTextView" id="script_start_time_field">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="tooltip_text" translatable="yes">Timestamp at which the Script execution started</property>
@@ -306,7 +314,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkTextView">
+              <object class="GtkTextView" id="script_crash_time_field">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="tooltip_text" translatable="yes">Timestamp at which the error occured</property>
@@ -322,7 +330,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkTextView">
+              <object class="GtkTextView" id="script_triggered_by_field">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="margin_top">2</property>
@@ -355,7 +363,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkTextView">
+          <object class="GtkTextView" id="crash_stack_trace_field">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="hexpand">True</property>

--- a/lib/autokey/gtkui/data/show_script_errors_dialog.xml
+++ b/lib/autokey/gtkui/data/show_script_errors_dialog.xml
@@ -1,0 +1,375 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <!-- interface-license-type gplv3 -->
+  <!-- interface-name AutoKey -->
+  <!-- interface-copyright 2020 -->
+  <!-- interface-authors Thomas Hess -->
+  <object class="GtkDialog">
+    <property name="can_focus">False</property>
+    <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-clear</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Clear the whole error list and close this window</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-delete</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Delete the currently shown error record</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Close this window, keeping all error records.</property>
+                <property name="use_stock">True</property>
+                <property name="always_show_image">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Shown below are the recorded errors that occurred in Scripts run by AutoKey during this session.</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Currently showing error</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="input_purpose">number</property>
+                <property name="numeric">True</property>
+                <property name="value">1</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">/</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">{}</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-goto-first</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Show the oldest recorded script error</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-go-back</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Show the previous recorded script error</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-go-forward</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Show the next recorded script error</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-goto-last</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="tooltip_text" translatable="yes">Show the newest recorded script error</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">8</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">8</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">2</property>
+            <property name="margin_right">2</property>
+            <property name="margin_top">3</property>
+            <property name="margin_bottom">2</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Crashed Script name:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Script start time:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Error occured at:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Script was triggered by:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkTextView">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">The name of the failed Script.</property>
+                <property name="margin_top">2</property>
+                <property name="margin_bottom">2</property>
+                <property name="hexpand">True</property>
+                <property name="editable">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkTextView">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Timestamp at which the Script execution started</property>
+                <property name="margin_top">2</property>
+                <property name="margin_bottom">2</property>
+                <property name="hexpand">True</property>
+                <property name="editable">False</property>
+                <property name="input_purpose">number</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkTextView">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Timestamp at which the error occured</property>
+                <property name="margin_top">2</property>
+                <property name="margin_bottom">2</property>
+                <property name="hexpand">True</property>
+                <property name="editable">False</property>
+                <property name="input_purpose">number</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkTextView">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="margin_top">2</property>
+                <property name="margin_bottom">2</property>
+                <property name="hexpand">True</property>
+                <property name="editable">False</property>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">The Python Stacktrace:</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkTextView">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="editable">False</property>
+            <property name="monospace">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/lib/autokey/gtkui/dialogs.py
+++ b/lib/autokey/gtkui/dialogs.py
@@ -15,25 +15,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import re
-from gi.repository import Gtk, Gdk
-
-#import gettext
 import locale
+import re
+import typing
+
+from gi.repository import Gtk, Gdk
 
 GETTEXT_DOMAIN = 'autokey'
 
 locale.setlocale(locale.LC_ALL, '')
-#for module in Gtk.glade, gettext:
-#    module.bindtextdomain(GETTEXT_DOMAIN)
-#    module.textdomain(GETTEXT_DOMAIN)
 
 
 __all__ = ["validate", "EMPTY_FIELD_REGEX", "AbbrSettingsDialog", "HotkeySettingsDialog", "WindowFilterSettingsDialog", "RecordDialog"]
 
-from .. import model, iomediator
+from autokey import model, iomediator
 from ..iomediator.key import Key
-# from . import configwindow
 from .configwindow0 import get_ui
 
 WORD_CHAR_OPTIONS = {

--- a/lib/autokey/gtkui/notifier.py
+++ b/lib/autokey/gtkui/notifier.py
@@ -138,10 +138,11 @@ class IndicatorNotifier:
         
     def on_show_error(self, widget, data=None):
         # Work around the current GUI design: the UI is destroyed when the main window is closed.
-        # This causes the show_script_error method below to fail. So open the main window first to circumvent issues.
-        # TODO: If the GTK GUI gets rewritten to not always destroy it’s UI, remove this comment and workaround.
-        self.on_show_configure(widget, data)
-        self.app.show_script_error(self.app.configWindow.ui)
+        # This causes the show_script_error method below to fail because self.app.configWindow.ui doesn’t exist
+        if self.app.configWindow is not None:
+            self.app.show_script_error(self.app.configWindow.ui)
+        else:
+            self.app.show_script_error(None)
         self.errorItem.hide()
         self.update_visible_status()
             

--- a/lib/autokey/model.py
+++ b/lib/autokey/model.py
@@ -16,9 +16,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import errno
+import datetime
 import re
 import os
 import os.path
+from pathlib import Path
 import glob
 import json
 import typing
@@ -1197,6 +1199,18 @@ class Script(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
 
     def __repr__(self):
         return "Script('" + self.description + "')"
+
+
+class ScriptErrorRecord:
+    """
+    This class holds a record of an error that caused a user Script to abort and additional meta-data .
+    """
+    def __init__(self, script: typing.Union[Script, Path], error_traceback: str,
+                 start_time: datetime.time, error_time: datetime.time):
+        self.script_name = script.description if isinstance(script, Script) else str(script)
+        self.error_traceback = error_traceback
+        self.start_time = start_time
+        self.error_time = error_time
 
 
 Item = typing.Union[Folder, Phrase, Script]

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -301,18 +301,6 @@ class Application(QApplication):
             message_box.setDetailedText(details)
         message_box.exec_()
 
-    def show_script_error(self):
-        """
-        Show the last script error (if any)
-        """
-        # TODO: i18n
-        if self.service.scriptRunner.error:
-            details = self.service.scriptRunner.error
-            self.service.scriptRunner.error = ''
-        else:
-            details = "No error information available"
-        QMessageBox.information(None, "View Script Error Details", details)
-
     def show_popup_menu(self, folders: list=None, items: list=None, onDesktop=True, title=None):
         if items is None:
             items = []

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -106,9 +106,6 @@ class Application(QApplication):
         logger.info("Initialising application")
         self.setWindowIcon(QIcon.fromTheme(common.ICON_FILE, ui_common.load_icon(ui_common.AutoKeyIcon.AUTOKEY)))
         try:
-
-            # Initialise logger
-
             if self._verify_not_running():
                 self._create_lock_file()
 
@@ -119,6 +116,11 @@ class Application(QApplication):
             self._try_start_service()
             self.notifier = Notifier(self)
             self.configWindow = ConfigWindow(self)
+            # Connect the mutual connections between the tray icon and the main window
+            self.configWindow.action_show_last_script_error.triggered.connect(self.notifier.reset_tray_icon)
+            self.notifier.action_view_script_error.triggered.connect(
+                self.configWindow.show_script_errors_dialog.update_and_show)
+
             self.monitor.start()
             # Initialise user code dir
             if self.configManager.userCodeDir is not None:

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -32,7 +32,7 @@ from PyQt5.QtWidgets import QMessageBox, QApplication
 from autokey import common
 common.USING_QT = True
 
-from autokey import service, monitor
+from autokey import service, monitor, model
 
 import autokey.argument_parser
 import autokey.configmanager.configmanager as cm
@@ -266,13 +266,15 @@ class Application(QApplication):
         os.remove(common.LOCK_FILE)  # TODO: maybe use atexit to remove the lock/pid file?
         logger.debug("All shutdown tasks complete... quitting")
 
-    def notify_error(self, message):
+    def notify_error(self, error: model.ScriptErrorRecord):
         """
         Show an error notification popup.
 
-        @param message: Message to show in the popup
+        @param error: The error that occurred in a Script
         """
+        message = "The script '{}' encountered an error".format(error.script_name)
         self.exec_in_main(self.notifier.notify_error, message)
+        self.configWindow.script_errors_available.emit(True)
 
     def update_notifier_visibility(self):
         self.notifier.update_visible_status()

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -117,7 +117,7 @@ class Application(QApplication):
             self.notifier = Notifier(self)
             self.configWindow = ConfigWindow(self)
             # Connect the mutual connections between the tray icon and the main window
-            self.configWindow.action_show_last_script_error.triggered.connect(self.notifier.reset_tray_icon)
+            self.configWindow.action_show_last_script_errors.triggered.connect(self.notifier.reset_tray_icon)
             self.notifier.action_view_script_error.triggered.connect(
                 self.configWindow.show_script_errors_dialog.update_and_show)
 

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -42,6 +42,7 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
         super().__init__()
         self.setupUi(self)
         self.about_dialog = dialogs.AboutAutokeyDialog(self)
+        self.show_script_errors_dialog = dialogs.ShowRecentScriptErrorsDialog(self)
         self.app = app
         self.action_create = self._create_action_create()
         self.toolbar.insertAction(self.action_save, self.action_create)  # Insert before action_save, i.e. at index 0
@@ -102,7 +103,7 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
 
     def _connect_all_tools_menu_signals(self):
         self.action_show_last_script_error.triggered.connect(self.app.notifier.reset_tray_icon)
-        self.action_show_last_script_error.triggered.connect(self.app.show_script_error)
+        self.action_show_last_script_error.triggered.connect(self.show_script_errors_dialog.update_and_show)
         self.action_record_script.triggered.connect(self.on_record)
         self.action_run_script.triggered.connect(self.on_run_script)
         # Add all defined macros to the »Insert Macros« menu

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -39,11 +39,16 @@ PROBLEM_MSG_SECONDARY = "%1\n\nYour changes have not been saved."
 
 class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwindow")):
 
+    script_errors_available = pyqtSignal(bool, name="script_errors_available")
+
     def __init__(self, app: QApplication):
         super().__init__()
         self.setupUi(self)
         self.about_dialog = dialogs.AboutAutokeyDialog(self)
         self.show_script_errors_dialog = dialogs.ShowRecentScriptErrorsDialog(self)
+        # Just forward the signal
+        self.show_script_errors_dialog.script_errors_available.connect(self.script_errors_available)
+
         self.app = app
         self.action_create = self._create_action_create()
         self.toolbar.insertAction(self.action_save, self.action_create)  # Insert before action_save, i.e. at index 0
@@ -104,6 +109,8 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
 
     def _connect_all_tools_menu_signals(self):
         self.action_show_last_script_error.triggered.connect(self.show_script_errors_dialog.update_and_show)
+        # Only enable the action if script errors are recorded. Disable the action if no errors are viewable.
+        self.script_errors_available.connect(self.action_show_last_script_error.setDisabled)
         self.action_record_script.triggered.connect(self.on_record)
         self.action_run_script.triggered.connect(self.on_run_script)
         # Add all defined macros to the »Insert Macros« menu

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -18,6 +18,7 @@ import threading
 import time
 import webbrowser
 
+from PyQt5.QtCore import pyqtSignal
 from PyQt5.QtGui import QIcon, QKeySequence, QCloseEvent
 from PyQt5.QtWidgets import QApplication, QAction, QMenu
 
@@ -102,7 +103,6 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
         self.action_rename_item.triggered.connect(self.central_widget.on_rename)
 
     def _connect_all_tools_menu_signals(self):
-        self.action_show_last_script_error.triggered.connect(self.app.notifier.reset_tray_icon)
         self.action_show_last_script_error.triggered.connect(self.show_script_errors_dialog.update_and_show)
         self.action_record_script.triggered.connect(self.on_record)
         self.action_run_script.triggered.connect(self.on_run_script)

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -108,9 +108,9 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
         self.action_rename_item.triggered.connect(self.central_widget.on_rename)
 
     def _connect_all_tools_menu_signals(self):
-        self.action_show_last_script_error.triggered.connect(self.show_script_errors_dialog.update_and_show)
+        self.action_show_last_script_errors.triggered.connect(self.show_script_errors_dialog.update_and_show)
         # Only enable the action if script errors are recorded. Disable the action if no errors are viewable.
-        self.script_errors_available.connect(self.action_show_last_script_error.setDisabled)
+        self.script_errors_available.connect(self.action_show_last_script_errors.setEnabled)
         self.action_record_script.triggered.connect(self.on_record)
         self.action_run_script.triggered.connect(self.on_run_script)
         # Add all defined macros to the »Insert Macros« menu

--- a/lib/autokey/qtui/configwindow.py
+++ b/lib/autokey/qtui/configwindow.py
@@ -18,7 +18,7 @@ import threading
 import time
 import webbrowser
 
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QTimer
 from PyQt5.QtGui import QIcon, QKeySequence, QCloseEvent
 from PyQt5.QtWidgets import QApplication, QAction, QMenu
 
@@ -286,14 +286,14 @@ class ConfigWindow(*autokey.qtui.common.inherits_from_ui_file_with_name("mainwin
             self.action_record_script.setChecked(False)
 
     def on_run_script(self):
-        t = threading.Thread(target=self._run_script)
-        t.start()
-
-    def _run_script(self):
         script = self.central_widget.get_selected_item()[0]
-        time.sleep(2)  # Fix the GUI tooltip for action_run_script when changing this!
-        self.app.service.scriptRunner.execute(script)
-    
+        QTimer.singleShot(
+            2000,  # Fix the GUI tooltip for action_run_script when changing this!
+            (lambda: self.app.service.scriptRunner.execute(
+                script
+            ))
+        )
+
     # Settings Menu
             
     def on_advanced_settings(self):

--- a/lib/autokey/qtui/dialogs/__init__.py
+++ b/lib/autokey/qtui/dialogs/__init__.py
@@ -27,7 +27,8 @@ __all__ = [
     "HotkeySettingsDialog",
     "GlobalHotkeyDialog",
     "WindowFilterSettingsDialog",
-    "RecordDialog"
+    "RecordDialog",
+    "ShowRecentScriptErrorsDialog"
 ]
 
 from autokey.qtui.common import EMPTY_FIELD_REGEX, validate
@@ -38,3 +39,4 @@ from .hotkeysettings import HotkeySettingsDialog, GlobalHotkeyDialog
 from .windowfiltersettings import WindowFilterSettingsDialog
 from .recorddialog import RecordDialog
 from .about_autokey_dialog import AboutAutokeyDialog
+from .show_recent_script_errors import ShowRecentScriptErrorsDialog

--- a/lib/autokey/qtui/dialogs/show_recent_script_errors.py
+++ b/lib/autokey/qtui/dialogs/show_recent_script_errors.py
@@ -39,6 +39,8 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
     # this and enables/disables itself based on the boolean value. The connection is defined in the .ui file.
     has_next_error = pyqtSignal(bool, name="has_next_error")
 
+    script_errors_available = pyqtSignal(bool, name="script_errors_available")
+
     def __init__(self, parent):
         super(ShowRecentScriptErrorsDialog, self).__init__(parent)
         self.setupUi(self)
@@ -50,6 +52,10 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
         self.recent_script_errors = QApplication.instance().\
             service.scriptRunner.error_records  # type: typing.List[ScriptErrorRecord]
         self.currently_viewed_error_index = 0
+
+    def hide(self):
+        self.script_errors_available.emit(bool(self.recent_script_errors))
+        super(ShowRecentScriptErrorsDialog, self).hide()
 
     @pyqtSlot(QAbstractButton)
     def handle_button_box_buttons(self, clicked_button: QAbstractButton):

--- a/lib/autokey/qtui/dialogs/show_recent_script_errors.py
+++ b/lib/autokey/qtui/dialogs/show_recent_script_errors.py
@@ -13,6 +13,14 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
+import typing
+
+from PyQt5.QtWidgets import QApplication, QAbstractButton, QDialogButtonBox
+from PyQt5.QtCore import pyqtSlot, pyqtSignal
+
+from autokey.model import ScriptErrorRecord
+
 from autokey.qtui import common as ui_common
 
 
@@ -21,5 +29,86 @@ logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("show_recent_script_errors_dialog")):
 
+    has_previous_error = pyqtSignal(bool, name="has_previous_error")
+    has_next_error = pyqtSignal(bool, name="has_next_error")
+
     def __init__(self, parent):
         super(ShowRecentScriptErrorsDialog, self).__init__(parent)
+        self.setupUi(self)
+        self.stack_trace_text_browser.setFontFamily("monospace")
+        self.buttonBox.clicked.connect(self.handle_button_box_buttons)
+
+        self.recent_script_errors = QApplication.instance().\
+            service.scriptRunner.error_records  # type: typing.List[ScriptErrorRecord]
+        self.currently_viewed_error_index = 0
+
+    @pyqtSlot(QAbstractButton)
+    def handle_button_box_buttons(self, clicked_button: QAbstractButton):
+        button_role = self.buttonBox.buttonRole(clicked_button)
+        if button_role == QDialogButtonBox.DestructiveRole:  # Discard current error
+            self.remove_currently_shown_error_from_error_list()
+        elif button_role == QDialogButtonBox.ResetRole:  # Clear the error list
+            self.clear_error_list()
+        # Close is handled internally and simply hides the dialogue.
+
+    @pyqtSlot()
+    def update_and_show(self):
+        error_count = len(self.recent_script_errors)
+        if error_count:
+            if self.currently_viewed_error_index >= error_count:
+                self.currently_viewed_error_index = error_count-1
+
+            self.has_next_error.emit(self.currently_viewed_error_index < error_count-1)
+            self.has_previous_error.emit(self.currently_viewed_error_index > 0)
+
+            logger.info("User views the last script errors. There are {} errors to review.".format(error_count))
+            self._show_error(self.currently_viewed_error_index)
+
+            self.show()
+        else:
+            logger.error(
+                "User is able to view the script error dialogue, even if no errors are available. "
+                "This should be impossible. Do not show the dialogue window.")
+
+    @pyqtSlot()
+    def show_next_error(self):
+        logger.debug("User views the next error.")
+        self.currently_viewed_error_index += 1
+        self.has_next_error.emit(self.currently_viewed_error_index < len(self.recent_script_errors)-1)
+        self._show_error(self.currently_viewed_error_index)
+
+    @pyqtSlot()
+    def show_previous_error(self):
+        logger.debug("User views the previous error.")
+        self.currently_viewed_error_index -= 1
+        self.has_previous_error.emit(self.currently_viewed_error_index > 0)
+        self._show_error(self.currently_viewed_error_index)
+
+    def remove_currently_shown_error_from_error_list(self):
+        error_count = len(self.recent_script_errors)
+        if error_count == 1:
+            self.clear_error_list()
+        else:
+            del self.recent_script_errors[self.currently_viewed_error_index]
+            if self.currently_viewed_error_index == error_count-1:
+                self.show_previous_error()
+            else:
+                self.has_next_error.emit(self.currently_viewed_error_index < len(self.recent_script_errors)-1)
+                self._show_error(self.currently_viewed_error_index)
+
+    def clear_error_list(self):
+        self.currently_viewed_error_index = 0
+        QApplication.instance().service.scriptRunner.clear_error_records()
+        self.hide()
+
+    def _show_error(self, script_at_index: int):
+        script_error = self.recent_script_errors[self.currently_viewed_error_index]
+        self.currently_shown_error_number_label.setText(str(script_at_index+1))
+        # Update the count on each show. This updates the GUI, if new errors occur while the
+        # dialogue window is shown and the user clicks on a previous or next button.
+        self.total_error_count_label.setText(str(len(self.recent_script_errors)))
+        self.script_start_time_edit.setTime(script_error.start_time)
+        self.script_error_time_edit.setTime(script_error.error_time)
+        self.script_name_view.setText(script_error.script_name)
+        self.stack_trace_text_browser.setText(script_error.error_traceback)
+

--- a/lib/autokey/qtui/dialogs/show_recent_script_errors.py
+++ b/lib/autokey/qtui/dialogs/show_recent_script_errors.py
@@ -1,0 +1,25 @@
+# Copyright (C) 2020 Thomas Hess <thomas.hess@udo.edu>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+from autokey.qtui import common as ui_common
+
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+
+class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("show_recent_script_errors_dialog")):
+
+    def __init__(self, parent):
+        super(ShowRecentScriptErrorsDialog, self).__init__(parent)

--- a/lib/autokey/qtui/dialogs/show_recent_script_errors.py
+++ b/lib/autokey/qtui/dialogs/show_recent_script_errors.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import datetime
 import typing
 
 from PyQt5.QtWidgets import QApplication, QAbstractButton, QDialogButtonBox
@@ -28,13 +27,23 @@ logger = __import__("autokey.logger").logger.get_logger(__name__)
 
 
 class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("show_recent_script_errors_dialog")):
+    """
+    This dialogue is used to show errors that caused user Scripts to abort. The ScriptRunner class holds a list
+    with errors, which can be viewed and cleared using this dialogue window.
+    """
 
+    # When switching errors, emit a boolean indicating if further errors are available. The Next button reacts on
+    # this and enables/disables itself based on the boolean value. The connection is defined in the .ui file.
     has_previous_error = pyqtSignal(bool, name="has_previous_error")
+    # When switching errors, emit a boolean indicating if previous errors are available. The Previous button reacts on
+    # this and enables/disables itself based on the boolean value. The connection is defined in the .ui file.
     has_next_error = pyqtSignal(bool, name="has_next_error")
 
     def __init__(self, parent):
         super(ShowRecentScriptErrorsDialog, self).__init__(parent)
         self.setupUi(self)
+        # This can’t be done in the UI editor, which can only set specific fonts. Just use the system default monospace
+        # font.
         self.stack_trace_text_browser.setFontFamily("monospace")
         self.buttonBox.clicked.connect(self.handle_button_box_buttons)
 
@@ -44,12 +53,16 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
 
     @pyqtSlot(QAbstractButton)
     def handle_button_box_buttons(self, clicked_button: QAbstractButton):
+        """
+        Used to connect the button presses with logic for 'Reset error list' and 'Discard current error' buttons in
+        the button box at the bottom of the dialogue window.
+        """
         button_role = self.buttonBox.buttonRole(clicked_button)
+        # The Close is handled internally and simply hides the dialogue, therefore nothing is implemented here.
         if button_role == QDialogButtonBox.DestructiveRole:  # Discard current error
             self.remove_currently_shown_error_from_error_list()
         elif button_role == QDialogButtonBox.ResetRole:  # Clear the error list
             self.clear_error_list()
-        # Close is handled internally and simply hides the dialogue.
 
     @pyqtSlot()
     def update_and_show(self):
@@ -72,19 +85,36 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
 
     @pyqtSlot()
     def show_next_error(self):
+        """
+        Switch to the next error in the error list.
+        The connection from the Next button to this slot function is defined in the .ui file.
+        """
         logger.debug("User views the next error.")
+        # Out of bounds handling is not needed, as the Next button gets disables when the last error is reached.
+        # See has_next_error Signal.
         self.currently_viewed_error_index += 1
         self.has_next_error.emit(self.currently_viewed_error_index < len(self.recent_script_errors)-1)
         self._show_error(self.currently_viewed_error_index)
 
     @pyqtSlot()
     def show_previous_error(self):
+        """
+        Switch to the previous error in the error list.
+        The connection from the Previous button to this slot function is defined in the .ui file.
+        """
         logger.debug("User views the previous error.")
+        # Out of bounds handling is not needed, as the Previous button gets disables when the first error is reached.
+        # See has_previous_error Signal.
         self.currently_viewed_error_index -= 1
         self.has_previous_error.emit(self.currently_viewed_error_index > 0)
         self._show_error(self.currently_viewed_error_index)
 
     def remove_currently_shown_error_from_error_list(self):
+        """
+        Delete the currently shown error from the error list.
+        Shows the next error, if available. Otherwise, show the previous error, if available.
+        Or clear the list and hide the window, if the deleted error was the only one in the list.
+        """
         error_count = len(self.recent_script_errors)
         if error_count == 1:
             self.clear_error_list()
@@ -97,11 +127,13 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
                 self._show_error(self.currently_viewed_error_index)
 
     def clear_error_list(self):
+        """Clears all errors in the error list and hides the dialogue window."""
         self.currently_viewed_error_index = 0
         QApplication.instance().service.scriptRunner.clear_error_records()
         self.hide()
 
     def _show_error(self, script_at_index: int):
+        """Update the GUI to show the error at the given list index."""
         script_error = self.recent_script_errors[self.currently_viewed_error_index]
         self.currently_shown_error_number_label.setText(str(script_at_index+1))
         # Update the count on each show. This updates the GUI, if new errors occur while the

--- a/lib/autokey/qtui/dialogs/windowfiltersettings.py
+++ b/lib/autokey/qtui/dialogs/windowfiltersettings.py
@@ -23,8 +23,6 @@ from autokey import iomediator
 from autokey import model
 
 
-# TODO: Once the port to Qt5 is done, enable the clearButtonEnable property for the line edit in the UI editor.
-# TODO: Pure Qt4 does not support the line edit clear button, so this functionality is currently unavailable.
 class WindowFilterSettingsDialog(*ui_common.inherits_from_ui_file_with_name("window_filter_settings_dialog")):
 
     def __init__(self, parent):

--- a/lib/autokey/qtui/notifier.py
+++ b/lib/autokey/qtui/notifier.py
@@ -114,7 +114,7 @@ class Notifier(QSystemTrayIcon):
             None, "&View script error", self.reset_tray_icon,
             "View the last script error."
         )
-        self.action_view_script_error.triggered.connect(self.app.show_script_error)
+        self.action_view_script_error.triggered.connect(self.app.configWindow.show_script_errors_dialog.update_and_show)
         # The action should disable itself
         self.action_view_script_error.setDisabled(True)
         self.action_view_script_error.triggered.connect(self.action_view_script_error.setEnabled)

--- a/lib/autokey/qtui/notifier.py
+++ b/lib/autokey/qtui/notifier.py
@@ -114,7 +114,6 @@ class Notifier(QSystemTrayIcon):
             None, "&View script error", self.reset_tray_icon,
             "View the last script error."
         )
-        self.action_view_script_error.triggered.connect(self.app.configWindow.show_script_errors_dialog.update_and_show)
         # The action should disable itself
         self.action_view_script_error.setDisabled(True)
         self.action_view_script_error.triggered.connect(self.action_view_script_error.setEnabled)

--- a/lib/autokey/qtui/resources/resources.qrc
+++ b/lib/autokey/qtui/resources/resources.qrc
@@ -16,6 +16,7 @@
     <file>ui/specialhotkeysettings.ui</file>
     <file>ui/settingsdialog.ui</file>
     <file>ui/about_autokey_dialog.ui</file>
+    <file>ui/show_recent_script_errors_dialog.ui</file>
     <!-- The icons are copied into the resource directory automatically during resource file compilation. -->
     <file>icons/autokey.png</file>
     <file>icons/autokey.svg</file>

--- a/lib/autokey/qtui/resources/ui/mainwindow.ui
+++ b/lib/autokey/qtui/resources/ui/mainwindow.ui
@@ -77,7 +77,7 @@
       <string>&amp;Insert Macro</string>
      </property>
     </widget>
-    <addaction name="action_show_last_script_error"/>
+    <addaction name="action_show_last_script_errors"/>
     <addaction name="action_record_script"/>
     <addaction name="action_run_script"/>
     <addaction name="separator"/>
@@ -352,16 +352,19 @@
     <string>F2</string>
    </property>
   </action>
-  <action name="action_show_last_script_error">
+  <action name="action_show_last_script_errors">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="icon">
     <iconset theme="dialog-error">
      <normaloff>../../../../../../../.designer/backup</normaloff>../../../../../../../.designer/backup</iconset>
    </property>
    <property name="text">
-    <string>&amp;Show last script error</string>
+    <string>&amp;Show last script errors</string>
    </property>
    <property name="toolTip">
-    <string>Show the last occured script error, if any.</string>
+    <string>Show the recently occured script errors.</string>
    </property>
   </action>
   <action name="action_enable_monitoring">

--- a/lib/autokey/qtui/resources/ui/mainwindow.ui
+++ b/lib/autokey/qtui/resources/ui/mainwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>784</width>
-    <height>587</height>
+    <width>878</width>
+    <height>574</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,7 +25,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>784</width>
+     <width>878</width>
      <height>30</height>
     </rect>
    </property>
@@ -123,7 +123,7 @@
     <enum>TopToolBarArea</enum>
    </attribute>
    <attribute name="toolBarBreak">
-    <bool>true</bool>
+    <bool>false</bool>
    </attribute>
    <addaction name="action_save"/>
    <addaction name="action_cut_item"/>

--- a/lib/autokey/qtui/resources/ui/mainwindow.ui
+++ b/lib/autokey/qtui/resources/ui/mainwindow.ui
@@ -361,10 +361,10 @@
      <normaloff>../../../../../../../.designer/backup</normaloff>../../../../../../../.designer/backup</iconset>
    </property>
    <property name="text">
-    <string>&amp;Show last script errors</string>
+    <string>&amp;Show recorded errors from Scripts</string>
    </property>
    <property name="toolTip">
-    <string>Show the recently occured script errors.</string>
+    <string>Show recorded errors that occured in recently-run Scripts.</string>
    </property>
   </action>
   <action name="action_enable_monitoring">

--- a/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
+++ b/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>View most recent Script errors</string>
+   <string>Show recorded errors from Scripts</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="3" column="0">
@@ -162,7 +162,7 @@
    <item row="0" column="0" colspan="2">
     <widget class="QLabel" name="dialog_header_label">
      <property name="text">
-      <string>Shown below are the most recent errors that occured in Scripts run by AutoKey during this session.</string>
+      <string>Shown below are the recorded errors that occurred in Scripts run by AutoKey during this session.</string>
      </property>
     </widget>
    </item>

--- a/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
+++ b/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>762</width>
+    <height>567</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>View most recent Script errors</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="1">
+    <widget class="QTimeEdit" name="script_error_time_edit">
+     <property name="inputMethodHints">
+      <set>Qt::ImhPreferNumbers|Qt::ImhTime</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="displayFormat">
+      <string>HH:mm:ss</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="script_triggered_by_header_label">
+     <property name="text">
+      <string>Script was triggered by:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="script_name_header_label">
+     <property name="text">
+      <string>Crashed Script name:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="script_start_time_header_label">
+     <property name="text">
+      <string>Script start time:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="show_error_number_header_label">
+       <property name="text">
+        <string>Currently showing error</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="currently_shown_error_number_label">
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="error_count_separator_label">
+       <property name="text">
+        <string>/</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="total_error_count_label">
+       <property name="text">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="show_previous_error_button">
+       <property name="text">
+        <string>Previous</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="show_next_error_button">
+       <property name="text">
+        <string>Next</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QTextBrowser" name="stack_trace_text_browser">
+     <property name="lineWrapMode">
+      <enum>QTextEdit::NoWrap</enum>
+     </property>
+     <property name="acceptRichText">
+      <bool>false</bool>
+     </property>
+     <property name="placeholderText">
+      <string notr="true">The failing script’s stack trace is shown here.</string>
+     </property>
+     <property name="openLinks">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Discard|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QTimeEdit" name="script_start_time_edit">
+     <property name="inputMethodHints">
+      <set>Qt::ImhPreferNumbers|Qt::ImhTime</set>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="displayFormat">
+      <string>HH:mm:ss</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="script_name_view">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="placeholderText">
+      <string>The failing Script’s name is shown here.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="dialog_header_label">
+     <property name="text">
+      <string>Shown below are the most recent errors that occured in Scripts run by AutoKey during this session.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="script_error_time_header_label">
+     <property name="text">
+      <string>Error occured at:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLabel" name="script_trigger_source_label">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
+++ b/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
@@ -33,6 +33,9 @@
    </item>
    <item row="5" column="1">
     <widget class="QTimeEdit" name="script_error_time_edit">
+     <property name="toolTip">
+      <string>Timestamp at which the error occured</string>
+     </property>
      <property name="inputMethodHints">
       <set>Qt::ImhPreferNumbers|Qt::ImhTime</set>
      </property>
@@ -184,6 +187,9 @@
    </item>
    <item row="4" column="1">
     <widget class="QTimeEdit" name="script_start_time_edit">
+     <property name="toolTip">
+      <string>Timestamp at which the Script execution started</string>
+     </property>
      <property name="inputMethodHints">
       <set>Qt::ImhPreferNumbers|Qt::ImhTime</set>
      </property>

--- a/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
+++ b/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>762</width>
-    <height>565</height>
+    <width>800</width>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,6 +39,9 @@
      <property name="readOnly">
       <bool>true</bool>
      </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::NoButtons</enum>
+     </property>
      <property name="displayFormat">
       <string>HH:mm:ss</string>
      </property>
@@ -54,23 +57,15 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="currently_shown_error_number_label">
-       <property name="text">
-        <string>1</string>
+      <widget class="QSpinBox" name="currently_shown_error_number_spin_box">
+       <property name="suffix">
+        <string> / {}</string>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="error_count_separator_label">
-       <property name="text">
-        <string>/</string>
+       <property name="minimum">
+        <number>1</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="total_error_count_label">
-       <property name="text">
-        <string>1</string>
+       <property name="singleStep">
+        <number>1</number>
        </property>
       </widget>
      </item>
@@ -88,16 +83,58 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="show_first_error_button">
+       <property name="toolTip">
+        <string>Show the oldest recorded script error.</string>
+       </property>
+       <property name="text">
+        <string>First</string>
+       </property>
+       <property name="icon">
+        <iconset theme="go-first">
+         <normaloff>.</normaloff>.</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="show_previous_error_button">
+       <property name="toolTip">
+        <string>Show the previous recorded script error.</string>
+       </property>
        <property name="text">
         <string>Previous</string>
+       </property>
+       <property name="icon">
+        <iconset theme="go-previous">
+         <normaloff>.</normaloff>.</iconset>
        </property>
       </widget>
      </item>
      <item>
       <widget class="QPushButton" name="show_next_error_button">
+       <property name="toolTip">
+        <string>Show the next recorded script error.</string>
+       </property>
        <property name="text">
         <string>Next</string>
+       </property>
+       <property name="icon">
+        <iconset theme="go-next">
+         <normaloff>.</normaloff>.</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="show_last_error_button">
+       <property name="toolTip">
+        <string>Show the newest recorded script error.</string>
+       </property>
+       <property name="text">
+        <string>Last</string>
+       </property>
+       <property name="icon">
+        <iconset theme="go-last">
+         <normaloff>.</normaloff>.</iconset>
        </property>
       </widget>
      </item>
@@ -125,6 +162,12 @@
    </item>
    <item row="8" column="0" colspan="2">
     <widget class="QTextBrowser" name="stack_trace_text_browser">
+     <property name="acceptDrops">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>The error message, as returned by Python.</string>
+     </property>
      <property name="lineWrapMode">
       <enum>QTextEdit::NoWrap</enum>
      </property>
@@ -146,6 +189,9 @@
      </property>
      <property name="readOnly">
       <bool>true</bool>
+     </property>
+     <property name="buttonSymbols">
+      <enum>QAbstractSpinBox::NoButtons</enum>
      </property>
      <property name="displayFormat">
       <string>HH:mm:ss</string>
@@ -209,8 +255,11 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>currently_shown_error_number_spin_box</tabstop>
+  <tabstop>show_first_error_button</tabstop>
   <tabstop>show_previous_error_button</tabstop>
   <tabstop>show_next_error_button</tabstop>
+  <tabstop>show_last_error_button</tabstop>
   <tabstop>script_name_view</tabstop>
   <tabstop>script_start_time_edit</tabstop>
   <tabstop>script_error_time_edit</tabstop>
@@ -225,8 +274,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>254</x>
-     <y>558</y>
+     <x>260</x>
+     <y>560</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -241,8 +290,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>322</x>
-     <y>558</y>
+     <x>328</x>
+     <y>560</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -257,8 +306,8 @@
    <slot>show_next_error()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>712</x>
-     <y>47</y>
+     <x>628</x>
+     <y>64</y>
     </hint>
     <hint type="destinationlabel">
      <x>380</x>
@@ -273,7 +322,39 @@
    <slot>show_previous_error()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>622</x>
+     <x>533</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>380</x>
+     <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_first_error_button</sender>
+   <signal>clicked()</signal>
+   <receiver>Dialog</receiver>
+   <slot>show_first_error()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>443</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>380</x>
+     <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_last_error_button</sender>
+   <signal>clicked()</signal>
+   <receiver>Dialog</receiver>
+   <slot>show_last_error()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>718</x>
      <y>47</y>
     </hint>
     <hint type="destinationlabel">
@@ -293,8 +374,8 @@
      <y>47</y>
     </hint>
     <hint type="destinationlabel">
-     <x>712</x>
-     <y>47</y>
+     <x>628</x>
+     <y>64</y>
     </hint>
    </hints>
   </connection>
@@ -305,12 +386,44 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>712</x>
+     <x>661</x>
      <y>47</y>
     </hint>
     <hint type="destinationlabel">
+     <x>533</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Dialog</sender>
+   <signal>has_next_error(bool)</signal>
+   <receiver>show_last_error_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
      <x>622</x>
      <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>718</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Dialog</sender>
+   <signal>has_previous_error(bool)</signal>
+   <receiver>show_first_error_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>661</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>443</x>
+     <y>64</y>
     </hint>
    </hints>
   </connection>
@@ -321,12 +434,28 @@
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>712</x>
-     <y>47</y>
+     <x>628</x>
+     <y>64</y>
     </hint>
     <hint type="destinationlabel">
-     <x>622</x>
-     <y>47</y>
+     <x>533</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_next_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_first_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>628</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>443</x>
+     <y>64</y>
     </hint>
    </hints>
   </connection>
@@ -337,12 +466,124 @@
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>622</x>
+     <x>533</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>628</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_previous_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_last_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>533</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>718</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_first_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_next_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>443</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>628</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_first_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_last_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>443</x>
+     <y>64</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>718</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_last_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_previous_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>718</x>
      <y>47</y>
     </hint>
     <hint type="destinationlabel">
-     <x>712</x>
+     <x>533</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_last_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_first_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>718</x>
      <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>443</x>
+     <y>64</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>currently_shown_error_number_spin_box</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>Dialog</receiver>
+   <slot>show_error_at_index(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>185</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>258</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>clicked(QAbstractButton*)</signal>
+   <receiver>Dialog</receiver>
+   <slot>handle_button_box_button_clicks(QAbstractButton*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>354</x>
+     <y>560</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>258</y>
     </hint>
    </hints>
   </connection>

--- a/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
+++ b/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
@@ -14,23 +14,13 @@
    <string>View most recent Script errors</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="1">
-    <widget class="QTimeEdit" name="script_error_time_edit">
-     <property name="inputMethodHints">
-      <set>Qt::ImhPreferNumbers|Qt::ImhTime</set>
+   <item row="3" column="0">
+    <widget class="QLabel" name="script_name_header_label">
+     <property name="text">
+      <string>Crashed Script name:</string>
      </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-     <property name="displayFormat">
-      <string>HH:mm:ss</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+     <property name="buddy">
+      <cstring>script_name_view</cstring>
      </property>
     </widget>
    </item>
@@ -41,17 +31,16 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="script_name_header_label">
-     <property name="text">
-      <string>Crashed Script name:</string>
+   <item row="5" column="1">
+    <widget class="QTimeEdit" name="script_error_time_edit">
+     <property name="inputMethodHints">
+      <set>Qt::ImhPreferNumbers|Qt::ImhTime</set>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="script_start_time_header_label">
-     <property name="text">
-      <string>Script start time:</string>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="displayFormat">
+      <string>HH:mm:ss</string>
      </property>
     </widget>
    </item>
@@ -114,7 +103,27 @@
      </item>
     </layout>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Discard|QDialogButtonBox::Reset</set>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="script_error_time_header_label">
+     <property name="text">
+      <string>Error occured at:</string>
+     </property>
+     <property name="buddy">
+      <cstring>script_error_time_edit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="2">
     <widget class="QTextBrowser" name="stack_trace_text_browser">
      <property name="lineWrapMode">
       <enum>QTextEdit::NoWrap</enum>
@@ -127,16 +136,6 @@
      </property>
      <property name="openLinks">
       <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Discard|QDialogButtonBox::Reset</set>
      </property>
     </widget>
    </item>
@@ -153,13 +152,10 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="script_name_view">
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-     <property name="placeholderText">
-      <string>The failing Script’s name is shown here.</string>
+   <item row="6" column="1">
+    <widget class="QLabel" name="script_trigger_source_label">
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>
@@ -170,17 +166,43 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="script_error_time_header_label">
-     <property name="text">
-      <string>Error occured at:</string>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="script_name_view">
+     <property name="toolTip">
+      <string>The name of the failed Script</string>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="placeholderText">
+      <string>The failing Script’s name is shown here.</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1">
-    <widget class="QLabel" name="script_trigger_source_label">
+   <item row="2" column="0" colspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="script_start_time_header_label">
      <property name="text">
-      <string/>
+      <string>Script start time:</string>
+     </property>
+     <property name="buddy">
+      <cstring>script_start_time_edit</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QLabel" name="stack_trace_header_label">
+     <property name="text">
+      <string>The Python Stacktrace:</string>
+     </property>
+     <property name="buddy">
+      <cstring>stack_trace_text_browser</cstring>
      </property>
     </widget>
    </item>

--- a/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
+++ b/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>762</width>
-    <height>567</height>
+    <height>565</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -186,6 +186,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>show_previous_error_button</tabstop>
+  <tabstop>show_next_error_button</tabstop>
+  <tabstop>script_name_view</tabstop>
+  <tabstop>script_start_time_edit</tabstop>
+  <tabstop>script_error_time_edit</tabstop>
+  <tabstop>stack_trace_text_browser</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>
@@ -195,8 +203,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>254</x>
+     <y>558</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -211,12 +219,108 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>322</x>
+     <y>558</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
      <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_next_error_button</sender>
+   <signal>clicked()</signal>
+   <receiver>Dialog</receiver>
+   <slot>show_next_error()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>712</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>380</x>
+     <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_previous_error_button</sender>
+   <signal>clicked()</signal>
+   <receiver>Dialog</receiver>
+   <slot>show_previous_error()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>622</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>380</x>
+     <y>282</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Dialog</sender>
+   <signal>has_next_error(bool)</signal>
+   <receiver>show_next_error_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>622</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>712</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Dialog</sender>
+   <signal>has_previous_error(bool)</signal>
+   <receiver>show_previous_error_button</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>712</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>622</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_next_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_previous_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>712</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>622</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>show_previous_error_button</sender>
+   <signal>clicked(bool)</signal>
+   <receiver>show_next_error_button</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>622</x>
+     <y>47</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>712</x>
+     <y>47</y>
     </hint>
    </hints>
   </connection>

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -354,7 +354,7 @@ Phrases created within temporary folders must themselves be explicitly set tempo
         path = path.expanduser()
         # Check if absolute path.
         if pathlib.PurePath(path).is_absolute() and path.exists():
-            self.runner.run_subscript_path(path)
+            self.runner.run_subscript(path)
         else:
             target_script = None
             for item in self.configManager.allItems:

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -42,8 +42,8 @@ MAX_STACK_LENGTH = 150
 
 def threaded(f):
 
-    def wrapper(*args):
-        t = threading.Thread(target=f, args=args, name="Phrase-thread")
+    def wrapper(*args, **kwargs):
+        t = threading.Thread(target=f, args=args, kwargs=kwargs, name="Phrase-thread")
         t.setDaemon(False)
         t.start()
 

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -464,7 +464,6 @@ class ScriptRunner:
     def __init__(self, mediator: IoMediator, app):
         self.mediator = mediator
         self.app = app
-        self.error = ''  # TODO: Deprecated
         self.error_records = []  # type: typing.List[model.ScriptErrorRecord]
         self.scope = globals()
         self.scope["highlevel"] = autokey.scripting.highlevel

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -509,6 +509,10 @@ class ScriptRunner:
         scope["__file__"] = path.resolve()
         self._execute(scope, path)
 
+    def _record_error(self, error: model.ScriptErrorRecord):
+        self.error_records.append(error)
+        self.app.notify_error(error)
+
     def _execute(self, scope, script: typing.Union[model.Script, pathlib.Path]):
         script_code = script.read_text() if isinstance(script, pathlib.Path) else script.code
         start_time = datetime.datetime.now().time()
@@ -520,11 +524,10 @@ class ScriptRunner:
             logger.exception("Script error")
             traceback_str = traceback.format_exc()
 
-            self.error_records.append(model.ScriptErrorRecord(
+            self._record_error(model.ScriptErrorRecord(
                 script=script, error_traceback=traceback_str, start_time=start_time, error_time=error_time
             ))
-            self.error = "Script name: '{}'\n{}".format(script.description, traceback_str)
-            self.app.notify_error("The script '{}' encountered an error".format(script.description))
+
 
     @staticmethod
     def _set_triggered_abbreviation(scope: dict, buffer: str, trigger_character: str):


### PR DESCRIPTION
Rewritten how the `ScriptRunner` class handles errors in user scripts.
Instead of simply storing a single string, the class now creates a simple container object and pushes it into a list.
The user can then
- view all errors in order
- remove them individually (middle button with trash can icon)
- clear the list (leftmost button with reset icon)
- close the window without removing the error messages from the list. The plain Close button (red x) won’t delete data from the error list.

GUI screenshot (ignore the localized buttons in the button box, Qt automatically translates them):
![Script error](https://user-images.githubusercontent.com/2143820/74362077-539fc900-4dc8-11ea-9951-53afdcdc0af9.png)


TODO:
- [ ] Implement the GTK GUI dialogue
- [ ] Store the trigger mode, and abbreviation or hotkey, if applicable. Display that information, as it may be of use for debugging purposes.
- [ ] Some sort of rate limiting (store only last 1000 exceptions or so)
- [x] Maybe some further improvements, like a integer spin box to show the current error number. Can be used for easier navigation when the exception list is large.
- [ ] Add an API call? Maybe `engine.clear_error_records()`?

Edit: Getting the source of a triggered Script seems to be a quite challenging task. Some sources, like the DBus interface and the GUI buttons are easy to identify, but getting the actual triggered abbreviation is quite a task. :-1: 