### PR TITLE
Fix shortcuts in manpage

### DIFF
--- a/doc/man/autokey-run.1
+++ b/doc/man/autokey-run.1
@@ -45,10 +45,10 @@ Show summary of options.
 .B \-s, \-\-script [name]
 Run a script with the specified name.
 .TP
-.B \-c, \-\-phrase [name]
+.B \-p, \-\-phrase [name]
 Paste a phrase with the specified name.
 .TP
-.B \-c, \-\-folder [name]
+.B \-f, \-\-folder [name]
 Display a popup menu for the specified folder.
 .SH AUTHOR
 Chris Dekter.

--- a/doc/man/autokey-run.1
+++ b/doc/man/autokey-run.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH AUTOKEY-GTK "1" "August 19, 2009"
+.TH AUTOKEY-GTK "1" "February 02, 2020"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:


### PR DESCRIPTION
Fix shortcuts in manpage.
Shortcut "-c" doesn't exists.