### PR TITLE
Add dbus handlers for pause_service and unpause_service messages

### DIFF
--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -84,3 +84,11 @@ class AppService(dbus.service.Object):
     @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='s', out_signature='')
     def run_folder(self, name):
         self.app.service.run_folder(name)
+
+    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='', out_signature='')
+    def pause_service(self):
+        self.app.pause_service()
+
+    @dbus.service.method(dbus_interface='org.autokey.Service', in_signature='', out_signature='')
+    def unpause_service(self):
+        self.app.unpause_service()


### PR DESCRIPTION
This PR adds dbus handlers to pause and unpause autokey. This allows someone to pause/unpause autokey when using software KVMs like [Barrier](https://github.com/debauchee/barrier):

```bash
# Pause autokey when switching to Mac
dbus-send --session --type=method_call --dest="org.autokey.Service" \
    "/AppService" "org.autokey.Service.pause_service"

# Unpause autokey when switching back to Linux
dbus-send --session --type=method_call --dest="org.autokey.Service" \
    "/AppService" "org.autokey.Service.unpause_service"
```