### PR TITLE
Add wait_for_keyevent scripting function

### DIFF
--- a/lib/autokey/iomediator/_iomediator.py
+++ b/lib/autokey/iomediator/_iomediator.py
@@ -109,14 +109,18 @@ class IoMediator(threading.Thread):
             shifted = self.modifiers[Key.CAPSLOCK] ^ self.modifiers[Key.SHIFT]
             key = self.interface.lookup_string(keyCode, shifted, numLock, self.modifiers[Key.ALT_GR])
             rawKey = self.interface.lookup_string(keyCode, False, False, False)
-            
-            for target in self.listeners:
+
+            # We make a copy here because the wait_for... functions modify the listeners,
+            # and we want this processing cycle to complete before changing what happens
+            for target in self.listeners.copy():
                 target.handle_keypress(rawKey, modifiers, key, window_info)
                 
             self.queue.task_done()
             
     def handle_mouse_click(self, rootX, rootY, relX, relY, button, windowInfo):
-        for target in self.listeners:
+        # We make a copy here because the wait_for... functions modify the listeners,
+        # and we want this processing cycle to complete before changing what happens
+        for target in self.listeners.copy():
             target.handle_mouseclick(rootX, rootY, relX, relY, button, windowInfo)
         
     # Methods for expansion service ----

--- a/lib/autokey/iomediator/_waiter.py
+++ b/lib/autokey/iomediator/_waiter.py
@@ -1,20 +1,23 @@
 import threading
 
 from ._iomediator import IoMediator
-
+from typing import Callable, Any
 
 class Waiter:
     """
     Waits for a specified event to occur
     """
 
-    def __init__(self, rawKey, modifiers, button, timeOut):
+    def __init__(self, rawKey, modifiers, button, check: Callable[[Any,str,list,str], bool], name: str, timeOut):
         IoMediator.listeners.append(self)
         self.rawKey = rawKey
         self.modifiers = modifiers
         self.button = button
         self.event = threading.Event()
+        self.check = check
+        self.name = name
         self.timeOut = timeOut
+        self.result = ''
 
         if modifiers is not None:
             self.modifiers.sort()
@@ -23,7 +26,7 @@ class Waiter:
         return self.event.wait(self.timeOut)
 
     def handle_keypress(self, rawKey, modifiers, key, *args):
-        if rawKey == self.rawKey and modifiers == self.modifiers:
+        if (rawKey == self.rawKey and modifiers == self.modifiers) or (self.check is not None and self.check(self, rawKey, modifiers, key, *args)):
             IoMediator.listeners.remove(self)
             self.event.set()
 

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -76,6 +76,7 @@ class Service:
         self.inputStack = collections.deque(maxlen=MAX_STACK_LENGTH)
         self.lastStackState = ''
         self.lastMenu = None
+        self.name = None
 
     def start(self):
         self.mediator = IoMediator(self)


### PR DESCRIPTION
I've set myself a project to get autokey to support emacs style keybinds.
One of the difficulties of that is supporting the C-u <number> prefix to commands:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Prefix-Command-Arguments.html

To do that I need a scripting function that can wait for an arbitrary number of keystrokes, accumulate the result, and store it. To accomplish that I made a new scripting API wait_for_keyevent that takes a lambda/function that says when we are done, and potentially accumulates a result.

I also note that the existing wait_for_keypress API modifies the iomediator.listeners list in the middle of iterating over it. In most computer languages this is illegal and cause all sorts of issues, and non consistent behavior. In any case, it caused a problem for me because it immediately creates a call to the function with the same value. This would presumably cause a problem currently if you say had a script for C-x and then waited for keypress C-x again, it would immediately exit. Anyway, I fixed that by copying the list before iterating, which is the normal way one avoids these multi threaded iterator issues.

Documentation in the code comes with an example of how to use it to implement C-u