### PR TITLE
issue337 don't use dot files

### DIFF
--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -33,7 +33,7 @@ LOCK_FILE = os.path.join(RUN_DIR, "autokey.pid")
 
 APP_NAME = "autokey"
 CATALOG = ""
-VERSION = "0.95.10"
+VERSION = "0.95.11"
 HOMEPAGE = "https://github.com/autokey/autokey"
 AUTHOR = 'Chris Dekter'
 AUTHOR_EMAIL = 'cdekter@gmail.com'

--- a/lib/autokey/configmanager/configmanager.py
+++ b/lib/autokey/configmanager/configmanager.py
@@ -348,7 +348,7 @@ class ConfigManager:
 
                 # --- handle changes to folder settings
 
-                if baseName == ".folder.json":
+                if baseName == "folder.json":
                     folder = self.__checkExistingFolder(directory)
                     if folder is not None:
                         folder.load_from_serialized()

--- a/lib/autokey/configmanager/version_upgrading.py
+++ b/lib/autokey/configmanager/version_upgrading.py
@@ -54,6 +54,8 @@ def upgrade_configuration(configuration_manager, config_data: dict):
         configuration_manager.config_altered(True)
     if version < "0.95.3":
         convert_autostart_entries_for_v0_95_3()
+    if version < "0.95.11":
+        convertDotFiles_v95_11(config_data)
     # Put additional conversion steps here.
 
 
@@ -125,3 +127,16 @@ def convert_autostart_entries_for_v0_95_3():
             old_autostart_file, new_file_name)
         )
         old_autostart_file.rename(new_file_name)
+
+def convertDotFiles_v95_11_folder(p: Path):
+    for name in p.glob('.*.json'):
+        new_json = p / name.name[1:]
+        name.rename(new_json)
+
+    for name in p.iterdir():
+        if name.is_dir():
+            convertDotFiles_v95_11_folder(name)
+
+def convertDotFiles_v95_11(configData):
+    for name in configData["folders"]:
+        convertDotFiles_v95_11_folder(Path(name))

--- a/lib/autokey/model/folder.py
+++ b/lib/autokey/model/folder.py
@@ -68,7 +68,7 @@ class Folder(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
         if not os.path.exists(self.path):
             os.mkdir(self.path)
 
-        with open(self.path + "/.folder.json", 'w') as outFile:
+        with open(self.path + "/folder.json", 'w') as outFile:
             json.dump(self.get_serializable(), outFile, indent=4)
 
     def get_serializable(self):
@@ -119,7 +119,7 @@ class Folder(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
 
     def load_from_serialized(self):
         try:
-            with open(self.path + "/.folder.json", 'r') as inFile:
+            with open(self.path + "/folder.json", 'r') as inFile:
                 data = json.load(inFile)
                 self.inject_json_data(data)
         except Exception:
@@ -172,7 +172,7 @@ class Folder(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
                     raise
 
     def get_json_path(self):
-        return self.path + "/.folder.json"
+        return self.path + "/folder.json"
 
     def get_tuple(self):
         return "folder", self.title, self.get_abbreviations(), self.get_hotkey_string(), self

--- a/lib/autokey/model/helpers.py
+++ b/lib/autokey/model/helpers.py
@@ -19,7 +19,7 @@ import os
 import re
 
 DEFAULT_WORDCHAR_REGEX = '[\w]'
-JSON_FILE_PATTERN = "{}/.{}.json"
+JSON_FILE_PATTERN = "{}/{}.json"
 SPACES_RE = re.compile(r"^ | $")
 
 
@@ -41,12 +41,12 @@ def get_safe_path(base_path, name, ext=""):
         n = 2
     else:
         path = base_path + '/' + safe_name + ext
-        jsonPath = base_path + '/.' + safe_name + ".json"
+        jsonPath = base_path + '/' + safe_name + ".json"
         n = 1
 
     while os.path.exists(path) or os.path.exists(jsonPath):
         path = base_path + '/' + safe_name + str(n) + ext
-        jsonPath = base_path + '/.' + safe_name + str(n) + ".json"
+        jsonPath = base_path + '/' + safe_name + str(n) + ".json"
         n += 1
 
     return path


### PR DESCRIPTION
A fix for issue 337: Stop hiding the sidecar files for phrases and scripts #337

#337

json config files no longer hidden by "." in filename.