### PR TITLE
Add wait_for_keyevent scripting function

### DIFF
--- a/lib/autokey/iomediator/waiter.py
+++ b/lib/autokey/iomediator/waiter.py
@@ -15,7 +15,8 @@
 
 import threading
 
-from .iomediator import IoMediator
+# from .iomediator import IoMediator
+from typing import Callable, Any
 
 
 class Waiter:
@@ -23,13 +24,16 @@ class Waiter:
     Waits for a specified event to occur
     """
 
-    def __init__(self, raw_key, modifiers, button, time_out):
-        IoMediator.listeners.append(self)
+    def __init__(self, raw_key, modifiers, button, check: Callable[[Any,str,list,str], bool], name: str, time_out):
+        # IoMediator.listeners.append(self)
         self.raw_key = raw_key
         self.modifiers = modifiers
         self.button = button
         self.event = threading.Event()
+        self.check = check
+        self.name = name
         self.time_out = time_out
+        self.result = ''
 
         if modifiers is not None:
             self.modifiers.sort()
@@ -38,8 +42,8 @@ class Waiter:
         return self.event.wait(self.time_out)
 
     def handle_keypress(self, raw_key, modifiers, key, *args):
-        if raw_key == self.raw_key and modifiers == self.modifiers:
-            IoMediator.listeners.remove(self)
+        if (raw_key == self.raw_key and modifiers == self.modifiers) or (self.check is not None and self.check(self, raw_key, modifiers, key, *args)):
+            # IoMediator.listeners.remove(self)
             self.event.set()
 
     def handle_mouseclick(self, root_x, root_y, rel_x, rel_y, button, window_info):

--- a/lib/autokey/scripting/keyboard.py
+++ b/lib/autokey/scripting/keyboard.py
@@ -156,6 +156,7 @@ class Keyboard:
             else: # accumulate as a string
                 waiter.result = waiter.result + key
                 return False
+                
         keyboard.wait_for_keyevent(check, "emacs-prefix")
         """
         if name is None or not any(elem.name == name for elem in self.mediator.listeners):

--- a/lib/autokey/scripting/keyboard.py
+++ b/lib/autokey/scripting/keyboard.py
@@ -139,23 +139,23 @@ class Keyboard:
         # Accumulate the traditional emacs C-u prefix arguments
         # See https://www.gnu.org/software/emacs/manual/html_node/elisp/Prefix-Command-Arguments.html
         def check(waiter,rawKey,modifiers,key,*args):
-        isCtrlU = (key == 'u' and len(modifiers) == 1 and modifiers[0] == '<ctrl>')
-        if isCtrlU: # If we get here, they've already pressed C-u at least 2x
-            try:
-                val = int(waiter.result) * 4
-                waiter.result = str(val)
-            except ValueError:
-                waiter.result = "16"
-            return False
-        elif any(m == "<ctrl>" or m == "<alt>" or m == "<meta>" or m == "<super>" or m == "<hyper>" for m in modifiers):
-            # Some other control character is an indication we're done.
-            if waiter.result is None or waiter.result == "":
-                waiter.result = "4"
-            store.set_global_value("emacs-prefix-arg", waiter.result)
-            return True
-        else: # accumulate as a string
-            waiter.result = waiter.result + key
-            return False
+            isCtrlU = (key == 'u' and len(modifiers) == 1 and modifiers[0] == '<ctrl>')
+            if isCtrlU: # If we get here, they've already pressed C-u at least 2x
+                try:
+                    val = int(waiter.result) * 4
+                    waiter.result = str(val)
+                except ValueError:
+                    waiter.result = "16"
+                return False
+            elif any(m == "<ctrl>" or m == "<alt>" or m == "<meta>" or m == "<super>" or m == "<hyper>" for m in modifiers):
+                # Some other control character is an indication we're done.
+                if waiter.result is None or waiter.result == "":
+                    waiter.result = "4"
+                store.set_global_value("emacs-prefix-arg", waiter.result)
+                return True
+            else: # accumulate as a string
+                waiter.result = waiter.result + key
+                return False
         keyboard.wait_for_keyevent(check, "emacs-prefix")
         """
         if name is None or not any(elem.name == name for elem in self.mediator.listeners):

--- a/lib/autokey/scripting/keyboard.py
+++ b/lib/autokey/scripting/keyboard.py
@@ -17,7 +17,7 @@ import typing
 
 import autokey.model.phrase
 from autokey import iomediator, model
-
+from typing import Callable
 
 class Keyboard:
     """
@@ -122,9 +122,49 @@ class Keyboard:
         """
         if modifiers is None:
             modifiers = []
-        w = iomediator.waiter.Waiter(key, modifiers, None, timeOut)
-        return w.wait()
+        w = self.mediator.waiter(key, modifiers, None, None, None, timeOut)
+        self.mediator.listeners.append(w)
+        rtn = w.wait()
+        self.mediator.listeners.remove(w)
+        return rtn
 
+    def wait_for_keyevent(self, check: Callable[[any,str,list,str], bool], name: str = None, timeOut=10.0):
+        """
+        Wait for a key event, potentially accumulating the intervening characters
+        Usage: C{keyboard.wait_for_keypress(self, check, name=None, timeOut=10.0)}
+        @param check: a function that returns True or False to signify we've finished waiting
+        @param name: only one waiter can have this name. Used to prevent more threads waiting on this.
+        @param timeOut: maximum time, in seconds, to wait for the keypress to occur
+        Example:
+        # Accumulate the traditional emacs C-u prefix arguments
+        # See https://www.gnu.org/software/emacs/manual/html_node/elisp/Prefix-Command-Arguments.html
+        def check(waiter,rawKey,modifiers,key,*args):
+        isCtrlU = (key == 'u' and len(modifiers) == 1 and modifiers[0] == '<ctrl>')
+        if isCtrlU: # If we get here, they've already pressed C-u at least 2x
+            try:
+                val = int(waiter.result) * 4
+                waiter.result = str(val)
+            except ValueError:
+                waiter.result = "16"
+            return False
+        elif any(m == "<ctrl>" or m == "<alt>" or m == "<meta>" or m == "<super>" or m == "<hyper>" for m in modifiers):
+            # Some other control character is an indication we're done.
+            if waiter.result is None or waiter.result == "":
+                waiter.result = "4"
+            store.set_global_value("emacs-prefix-arg", waiter.result)
+            return True
+        else: # accumulate as a string
+            waiter.result = waiter.result + key
+            return False
+        keyboard.wait_for_keyevent(check, "emacs-prefix")
+        """
+        if name is None or not any(elem.name == name for elem in self.mediator.listeners):
+            w = self.mediator.waiter(None, None, None, check, name, timeOut)
+            self.mediator.listeners.append(w)
+            rtn = w.wait()
+            self.mediator.listeners.remove(w)
+            return rtn
+        return False
 
 def _validate_send_mode(send_mode):
     permissible_values = "\n".join("keyboard.{}".format(mode) for mode in map(str, autokey.model.phrase.SendMode))

--- a/lib/autokey/scripting/mouse.py
+++ b/lib/autokey/scripting/mouse.py
@@ -73,5 +73,5 @@ class Mouse:
         @param timeOut: maximum time, in seconds, to wait for the keypress to occur
         """
         button = int(button)
-        w = autokey.iomediator.waiter.Waiter(None, None, button, timeOut)
+        w = autokey.iomediator.waiter.Waiter(None, None, button, None, None, timeOut)
         w.wait()

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -84,6 +84,7 @@ class Service:
         self.inputStack = collections.deque(maxlen=MAX_STACK_LENGTH)
         self.lastStackState = ''
         self.lastMenu = None
+        self.name = None
 
     def start(self):
         self.mediator = IoMediator(self)
@@ -525,6 +526,7 @@ class ScriptRunner:
             compiled_code = self._compile_script(script)
             exec(compiled_code, scope)
         except Exception:  # Catch everything raised by the User code. Those Exceptions must not crash the thread.
+            traceback.print_exc()
             self._record_error(script, start_time)
 
     @staticmethod


### PR DESCRIPTION
I've set myself a project to get autokey to support emacs style keybinds.
One of the difficulties of that is supporting the C-u prefix to commands:
https://www.gnu.org/software/emacs/manual/html_node/elisp/Prefix-Command-Arguments.html

To do that I need a scripting function that can wait for an arbitrary number of keystrokes, accumulate the result, and store it. To accomplish that I made a new scripting API wait_for_keyevent that takes a lambda/function that says when we are done, and potentially accumulates a result.

I also note that the existing wait_for_keypress API modifies the iomediator.listeners list in the middle of iterating over it. In most computer languages this is illegal and cause all sorts of issues, and non consistent behavior. In any case, it caused a problem for me because it immediately creates a call to the function with the same value. This would presumably cause a problem currently if you say had a script for C-x and then waited for keypress C-x again, it would immediately exit. Anyway, I fixed that by copying the list before iterating, which is the normal way one avoids these multi threaded iterator issues.

Documentation in the code comes with an example of how to use it to implement C-u

Regarding the implementation, I note that the develop branch has broken the pre-existing wait_for_keypress function. I've fixed it at the same time, although the code has undergone quite a bit of restructuring since master, and I'm not fully sure of the intention. It seems like the intention is that all the functionality is supposed to go via the keyboard.mediator proxy. That makes accessing the Waiter class difficult. I've added a waiter member to the iomediator to solve this, but that means Waiter can't access iomediator (circular dependency). So that means wait_for_keypress now adds itself to listeners. Feel free to give advice if there's a better way, but this works.

        Wait for a key event, potentially accumulating the intervening characters
        Usage: C{keyboard.wait_for_keypress(self, check, name=None, timeOut=10.0)}
        @param check: a function that returns True or False to signify we've finished waiting
        @param name: only one waiter can have this name. Used to prevent more threads waiting on this.
        @param timeOut: maximum time, in seconds, to wait for the keypress to occur
        Example:
        # Accumulate the traditional emacs C-u prefix arguments
        # See https://www.gnu.org/software/emacs/manual/html_node/elisp/Prefix-Command-Arguments.html
        def check(waiter,rawKey,modifiers,key,*args):
            isCtrlU = (key == 'u' and len(modifiers) == 1 and modifiers[0] == '<ctrl>')
            if isCtrlU: # If we get here, they've already pressed C-u at least 2x
                try:
                    val = int(waiter.result) * 4
                    waiter.result = str(val)
                except ValueError:
                    waiter.result = "16"
                return False
            elif any(m == "<ctrl>" or m == "<alt>" or m == "<meta>" or m == "<super>" or m == "<hyper>" for m in modifiers):
                # Some other control character is an indication we're done.
                if waiter.result is None or waiter.result == "":
                    waiter.result = "4"
                store.set_global_value("emacs-prefix-arg", waiter.result)
                return True
            else: # accumulate as a string
                waiter.result = waiter.result + key
                return False

        keyboard.wait_for_keyevent(check, "emacs-prefix")