### PR TITLE
Fix for TriggerMode.HOTKEY (3) showing up in modes in the save file t…

### DIFF
--- a/lib/autokey/gtkui/settingsdialog.py
+++ b/lib/autokey/gtkui/settingsdialog.py
@@ -111,7 +111,9 @@ class SettingsDialog:
         else:
             autokey.configmanager.autostart.delete_autostart_entry()
 
-        cm.ConfigManager.SETTINGS[cm_constants.PROMPT_TO_SAVE] = not self.promptToSaveCheckbox.get_active()
+
+        #promptToSaveCheckbox no longer exists? This prevented saving in the Preferences window from what I can tell
+        #cm.ConfigManager.SETTINGS[cm_constants.PROMPT_TO_SAVE] = not self.promptToSaveCheckbox.get_active()
         cm.ConfigManager.SETTINGS[cm_constants.SHOW_TRAY_ICON] = self.showTrayCheckbox.get_active()
         #cm.ConfigManager.SETTINGS[MENU_TAKES_FOCUS] = self.allowKbNavCheckbox.get_active()
         cm.ConfigManager.SETTINGS[cm_constants.SORT_BY_USAGE_COUNT] = self.sortByUsageCheckbox.get_active()

--- a/lib/autokey/model/abstract_hotkey.py
+++ b/lib/autokey/model/abstract_hotkey.py
@@ -45,7 +45,7 @@ class AbstractHotkey(AbstractWindowFilter):
         modifiers.sort()
         self.modifiers = modifiers
         self.hotKey = key
-        if key is not None:
+        if key is not None and TriggerMode.HOTKEY not in self.modes:
             self.modes.append(TriggerMode.HOTKEY)
 
     def unset_hotkey(self):


### PR DESCRIPTION
…wice.

Previously saving would add 3, and only 3, twice to the modes portion of the save file.

And fix for the preferences window not saving changes