### PR TITLE
Change "Help/Scripting Help" link to new Github documentation link.

### DIFF
--- a/lib/autokey/common.py
+++ b/lib/autokey/common.py
@@ -49,7 +49,7 @@ MAINTAINER_EMAIL = 'guociz@gmail.com'
 BUG_EMAIL = "guociz@gmail.com"
 
 FAQ_URL = "https://github.com/autokey/autokey/wiki/FAQ"
-API_URL = "https://autokey.github.io/"
+API_URL = "https://github.com/autokey/autokey/wiki/API-Examples"
 HELP_URL = "https://github.com/autokey/autokey/wiki/Troubleshooting"
 BUG_URL = HOMEPAGE + "/issues"
 


### PR DESCRIPTION
Update link from older documentation to new wiki documentation