### PR TITLE
Fix for hotkeys still being applied when cleared (my fault `not` wher…

### DIFF
--- a/lib/autokey/model/abstract_hotkey.py
+++ b/lib/autokey/model/abstract_hotkey.py
@@ -45,7 +45,7 @@ class AbstractHotkey(AbstractWindowFilter):
         modifiers.sort()
         self.modifiers = modifiers
         self.hotKey = key
-        if key is not None and TriggerMode.HOTKEY not in self.modes:
+        if key is not None and TriggerMode.HOTKEY in self.modes:
             self.modes.append(TriggerMode.HOTKEY)
 
     def unset_hotkey(self):


### PR DESCRIPTION
…e there shouldn't have been one)