### PR TITLE
Add more functions to window API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -55,6 +55,14 @@ Scripting API
 
 - Add mouse drag, click and scroll options to the API.
 
+**New window API method**
+
+- Adds `center_window` to center selected window on selected monitor.
+- Adds `get_window_geom` to fetch the window geometry of a window.
+- Adds `get_window_hex` to get the hex id of the first window that matches the given title.
+- Adds `get_window_list` to get list of windows via `wmctrl`.
+
+
 Command line interface
 ++++++++++++++++++++++
 

--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -21,7 +21,7 @@ gtk_modules = ['gi', 'gi.repository.Gtk', 'gi.repository.Gdk', 'gi.repository.Pa
 qt_modules = ['PyQt5', 'PyQt5.QtGui', 'PyQt5.QtWidgets', 'PyQt5.QtCore',
             'PyQt5.Qsci']
 
-common_programs = ['wmctrl', 'ps']
+common_programs = ['wmctrl', 'ps', 'xrandr']
 # Checking some of these appears to be redundant as some are provided by the same packages on my system but 
 # better safe than sorry.
 optional_programs = ['visgrep', 'import', 'png2pat', 'xte', 'xmousepos']

--- a/lib/autokey/scripting/window.py
+++ b/lib/autokey/scripting/window.py
@@ -13,12 +13,22 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Basic window management. Requies C{wmctrl} to be installed."""
+"""Basic window management. Requies C{wmctrl} and C{xrandr} to be installed."""
 
 import re
 import subprocess
 import time
 
+
+# this regex extracts the pertinant data from wmctrl output, see test_window.py for more info
+WMCTRL_GEOM_REGEX = r"^(0x[0-9a-fA-F]{8})\s{1,}(\d*)\s{1,}(\d*)\s{1,}(\d{1,})\s{1,}(\d{1,})\s{1,}(\d{1,})\s{1,}(.*?)\s{1,}(.*?)$"
+XRANDR_MONITOR_REGEX = r" (\d{3,4}).*?x(\d{3,4})\/.*?\+(\d{1,4})\+(\d{1,4})"
+#Example Output:
+#Monitors: 2
+# 0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
+# 1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0
+# Regex gets  ____ and ____    ____ _
+# this translates to monitor x and y size, and x and y offset for each monitor
 
 class Window:
     """
@@ -61,7 +71,7 @@ class Window:
 
         return False
 
-    def wait_for_exist(self, title, timeOut=5):
+    def wait_for_exist(self, title, timeOut=5, by_hex=False):
         """
         Wait for window with the given title to be created
 
@@ -72,15 +82,17 @@ class Window:
 
         @param title: title to match against (as a regular expression)
         @param timeOut: period (seconds) to wait before giving up
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
         @rtype: boolean
         """
-        regex = re.compile(title)
         waited = 0
         while waited <= timeOut:
-            retCode, output = self._run_wmctrl(["-l"])
-            for line in output.split('\n'):
-                if regex.match(line[14:].split(' ', 1)[-1]):
-                    return True
+            windowList = self.get_window_list()
+            for window in windowList:
+                if by_hex:
+                    if title == window[0]: return True
+                else:
+                    if title == window[3]: return True
 
             if timeOut == 0:
                 break  # zero length timeout, if not matched go straight to end
@@ -90,7 +102,7 @@ class Window:
 
         return False
 
-    def activate(self, title, switchDesktop=False, matchClass=False):
+    def activate(self, title, switchDesktop=False, matchClass=False, by_hex=False):
         """
         Activate the specified window, giving it input focus
 
@@ -102,16 +114,21 @@ class Window:
         @param title: window title to match against (as case-insensitive substring match)
         @param switchDesktop: whether or not to switch to the window's current desktop
         @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
         """
         if switchDesktop:
-            args = ["-a", title]
+            xArgs = ["-a", title]
         else:
-            args = ["-R", title]
-        if matchClass:
-            args += ["-x"]
-        self._run_wmctrl(args)
+            xArgs = ["-R", title]
 
-    def close(self, title, matchClass=False):
+        if by_hex:
+            xArgs += ["-i"] # use hex id instead of window title
+
+        if matchClass:
+            xArgs += ["-x"]
+        self._run_wmctrl(xArgs)
+
+    def close(self, title, matchClass=False, by_hex=False):
         """
         Close the specified window gracefully
 
@@ -119,17 +136,21 @@ class Window:
 
         @param title: window title to match against (as case-insensitive substring match)
         @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
         """
+        xArgs = ["-c", title]
         if matchClass:
-            self._run_wmctrl(["-c", title, "-x"])
-        else:
-            self._run_wmctrl(["-c", title])
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
 
-    def resize_move(self, title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False):
+        self._run_wmctrl(xArgs)
+
+    def resize_move(self, title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False, by_hex=False):
         """
         Resize and/or move the specified window
 
-        Usage: C{window.close(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False)}
+        Usage: C{window.resize_move(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False)}
 
         Leaving and of the position/dimension values as the default (-1) will cause that
         value to be left unmodified.
@@ -139,16 +160,18 @@ class Window:
         @param yOrigin: new y origin of the window (upper left corner)
         @param width: new width of the window
         @param height: new height of the window
-        @param matchClass: if True, match on the window class instead of the title
+        @param matchClass: if C{True}, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
         """
         mvArgs = ["0", str(xOrigin), str(yOrigin), str(width), str(height)]
+        xArgs = []
         if matchClass:
-            xArgs = ["-x"]
-        else:
-            xArgs = []
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
         self._run_wmctrl(["-r", title, "-e", ','.join(mvArgs)] + xArgs)
 
-    def move_to_desktop(self, title, deskNum, matchClass=False):
+    def move_to_desktop(self, title, deskNum, matchClass=False, by_hex=False):
         """
         Move the specified window to the given desktop
 
@@ -157,11 +180,13 @@ class Window:
         @param title: window title to match against (as case-insensitive substring match)
         @param deskNum: desktop to move the window to (note: zero based)
         @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
         """
+        xArgs = []
         if matchClass:
-            xArgs = ["-x"]
-        else:
-            xArgs = []
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
         self._run_wmctrl(["-r", title, "-t", str(deskNum)] + xArgs)
 
     def switch_desktop(self, deskNum):
@@ -174,7 +199,7 @@ class Window:
         """
         self._run_wmctrl(["-s", str(deskNum)])
 
-    def set_property(self, title, action, prop, matchClass=False):
+    def set_property(self, title, action, prop, matchClass=False, by_hex=False):
         """
         Set a property on the given window using the specified action
 
@@ -188,35 +213,26 @@ class Window:
         @param action: one of the actions listed above
         @param prop: one of the properties listed above
         @param matchClass: if True, match on the window class instead of the title
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
         """
+        xArgs = []
         if matchClass:
-            xArgs = ["-x"]
-        else:
-            xArgs = []
+            xArgs += ["-x"]
+        if by_hex:
+            xArgs += ["-i"]
         self._run_wmctrl(["-r", title, "-b" + action + ',' + prop] + xArgs)
 
     def get_active_geometry(self):
         """
-        Get the geometry of the currently active window
+        Get the geometry of the currently active window. Uses the C{:ACTIVE:} function of C{wmctrl}.
 
         Usage: C{window.get_active_geometry()}
 
         @return: a 4-tuple containing the x-origin, y-origin, width and height of the window (in pixels)
         @rtype: C{tuple(int, int, int, int)}
         """
-        active = self.mediator.interface.get_window_title()
-        result, output = self._run_wmctrl(["-l", "-G"])
-        matchingLine = None
-        for line in output.split('\n'):
-            if active in line[34:].split(' ', 1)[-1]:
-                matchingLine = line
-
-        if matchingLine is not None:
-            output = matchingLine.split()[2:6]
-            # return [int(x) for x in output]
-            return list(map(int, output))
-        else:
-            return None
+        #wrapper for get_window_geometry()
+        return self.get_window_geometry(":ACTIVE:")
 
     def get_active_title(self):
         """
@@ -240,7 +256,7 @@ class Window:
         """
         return self.mediator.interface.get_window_class()
 
-    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, monitor=0, matchClass=False):
+    def center_window(self, title=":ACTIVE:", win_width=None, win_height=None, monitor=0, matchClass=False, by_hex=False):
         """
         Centers the active (or window selected by title) window. Requires xrandr for getting monitor sizes and offsets.
 
@@ -250,22 +266,18 @@ class Window:
         @param monitor: Monitor number (0 is primary, listed via C{xrandr --listactivemonitors} etc.)
         @param matchClass: if True, match on the window class instead of the title
         @raises ValueError: If title or desktop is not found by wmctrl
+        @param by_hex: If true, C{wmctrl} will interpret the C{title} as a hexid
         """
         #could also use Gdk.Display.get_default().get_montiors etc.
-        #Used xrandr for ease of cross Gtk/Qt use
-        #Example Output:
-        #Monitors: 2
-        # 0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
-        # 1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0
-        # Regex gets  ____ and ____    ____ _
-        # this translates to monitor x and y size, and x and y offset for each monitor
+        #Used xrandr for ease of cross Gtk/Qt use, wayland might require an alternate implementation
         returncode, output = self._run_xrandr(["--listactivemonitors"])
-        regex = r" (\d{3,4}).*?x(\d{3,4})\/.*?\+(\d{1,4})\+(\d{1,4})"
-        matches = re.findall(regex, output, re.MULTILINE)
-        x_offset = int(matches[monitor][2])
-        y_offset = int(matches[monitor][3])
+        matches = re.findall(XRANDR_MONITOR_REGEX, output, re.MULTILINE)
+
         width = int(matches[monitor][0])
         height = int(matches[monitor][1])
+        x_offset = int(matches[monitor][2])
+        y_offset = int(matches[monitor][3])
+
         #work backwards from the size of the window
         if win_width is None:
             win_width = round(width/2)
@@ -275,10 +287,10 @@ class Window:
         top_y = round((height-win_height)/2)
 
         #remove maximized attributes from window
-        self.set_property(title, "remove", "maximized_vert", matchClass=matchClass)
-        self.set_property(title, "remove", "maximized_horz", matchClass=matchClass)
+        self.set_property(title, "remove", "maximized_vert", matchClass=matchClass, by_hex=by_hex)
+        self.set_property(title, "remove", "maximized_horz", matchClass=matchClass, by_hex=by_hex)
         #resize and move window
-        self.resize_move(title, x_offset+top_x, y_offset+top_y, win_width, win_height, matchClass=matchClass)
+        self.resize_move(title, x_offset+top_x, y_offset+top_y, win_width, win_height, matchClass=matchClass, by_hex=by_hex)
 
     def _run_xrandr(self, args):
         try:
@@ -300,7 +312,7 @@ class Window:
 
         return returncode, output
 
-    def get_window_list(self, filter_desktop=None):
+    def get_window_list(self, filter_desktop=-1):
         """
         Returns a list of windows matching an optional desktop filter, requires C{wmctrl}!
 
@@ -308,9 +320,9 @@ class Window:
 
         Where the C{hexid} is the ID used for some other functions (like L{import -window} from ImageMagick).
 
-        C{desktop} is the number of which desktop (sometimes called workspaces) the item appears upon.
+        C{desktop} is the number of which desktop (sometimes called workspaces) the window appears upon.
 
-        C{hostname} is the hostname of your computer (I'm not sure why this is included as it seems to be the same for everything I have seen)
+        C{hostname} is the hostname of your computer.
 
         C{title} is the title that you would usually see in your window manager of choice.
 
@@ -318,53 +330,61 @@ class Window:
         @return: C{[[hexid1, desktop1, hostname1, title1], [hexid2,desktop2,hostname2,title2], ...etc]}
         Returns C{[]} if no windows are found.
         """
-        returncode, output = self._run_wmctrl(["-l"])
-        # regex = r"^(0x[0-9a-fA-F]{8})  (\d*) (.*?) (.*?)$"
-        regex = r"^(0x[0-9a-fA-F]{8})\s*(\d*)\s*(.*?)\s(.*?)$"
-        matches = re.findall(regex, output, re.MULTILINE)
-        print(matches)
-        if filter_desktop is None:
-            return matches
-        else:
-            output = []
-            for match in matches:
-                hexid, desktop, hostname, window_title = match
-                if not filter_desktop==desktop:
-                    continue
-                output.append((hexid,desktop,hostname, window_title))
-            return output
+        returncode, output = self._run_wmctrl(["-lG"])
+        matches = re.findall(WMCTRL_GEOM_REGEX, output, re.MULTILINE)
+        output = []
+        for match in matches:
+            hexid = match[0]
+            desktop = match[1]
+            hostname = match[6]
+            window_title = match[7]
 
-    def get_window_hex(self, window_title):
+            if filter_desktop==desktop:
+                continue
+            output.append((hexid,desktop,hostname, window_title))
+        return output
+
+    def get_window_hex(self, title):
         """
-        Returns the hexid of the first window to match window_title.
+        Returns the hexid of the first window to match title.
 
-        @param window_title: Window title to match for returning hexid
+        @param title: Window title to match for returning hexid
         @return: Returns hexid of the window to be used for other functions See L{get_window_geom}, L{visgrep_by_window_id}
 
         Returns C{None} if no matches are found
         """
         windowList = self.get_window_list()
         for window in windowList:
-            if window_title in window[3]:
+            if title in window[3]:
                 return window[0]
         return None
 
 
 
 
-    def get_window_geom(self, window_id):
+    def get_window_geometry(self, title, by_hex=False):
         """
-        Uses C{wmctrl} to return the window geom of the given window_id. Returns where the location of the 
-        top left hand corner of the window is and how long/tall the window is.
+        Uses C{wmctrl} to return the window geometry of the given window title. Returns where the location of the
+        top left hand corner of the window is and the width/height of the window.
 
 
+        @param title
         @return: C{[offsetx, offsety, sizex, sizey]} Returns none if no matches are found
         """
 
+        index = -1 # by default use the window title for matching
+        if by_hex:
+            index = 0
+        if title == ":ACTIVE:":
+            if by_hex:
+                title = self.get_window_hex(self.get_active_title())
+            else:
+                title = self.get_active_title()
         returncode, output = self._run_wmctrl(["-lG"])
-        regex = r"^(0x[0-9a-fA-F]{8})\s*(\d*)\s*(\d*)\s*(\d{1,})\s*(\d{1,})\s*(\d{1,})\s*(.*?)$"
-        matches = re.findall(regex, output, re.MULTILINE)
+        matches = re.findall(WMCTRL_GEOM_REGEX, output, re.MULTILINE)
         for match in matches:
-            if match[0] == window_id:
-                return [int(i) for i in match[2:-1]] # trim hexid, gravity on the front end and title on the backend
+            if match[index] == title:
+                # trim hexid, gravity from front of list and the window title from end of list
+                # convert to ints and return
+                return list(map(int, match[2:-2]))
         return None

--- a/lib/autokey/scripting/window.py
+++ b/lib/autokey/scripting/window.py
@@ -27,7 +27,6 @@ class Window:
     Note: in all cases where a window title is required (with the exception of wait_for_focus()),
     two special values of window title are permitted:
 
-    #TODO should these be broken out into enums like keys/buttons
     :ACTIVE: - select the currently active window
     :SELECT: - select the desired window by clicking on it
     """
@@ -181,9 +180,7 @@ class Window:
 
         Usage: C{window.set_property(title, action, prop, matchClass=False)}
 
-        #TODO should these be broken out into enums like keys/buttons
         Allowable actions: C{add, remove, toggle}
-        #TODO should these be broken out into enums like keys/buttons
         Allowable properties: C{modal, sticky, maximized_vert, maximized_horz, shaded, skip_taskbar,
         skip_pager, hidden, fullscreen, above}
 
@@ -265,10 +262,10 @@ class Window:
         returncode, output = self._run_xrandr(["--listactivemonitors"])
         regex = r" (\d{3,4}).*?x(\d{3,4})\/.*?\+(\d{1,4})\+(\d{1,4})"
         matches = re.findall(regex, output, re.MULTILINE)
-
-        width, height = [int(i) for i in matches[monitor][0:2]]
-        x_offset, y_offset = [int(i) for i in matches[monitor][2:4]]
-
+        x_offset = int(matches[monitor][2])
+        y_offset = int(matches[monitor][3])
+        width = int(matches[monitor][0])
+        height = int(matches[monitor][1])
         #work backwards from the size of the window
         if win_width is None:
             win_width = round(width/2)

--- a/tests/scripting_api/test_window.py
+++ b/tests/scripting_api/test_window.py
@@ -1,9 +1,41 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import Mock, MagicMock, patch
+
 
 import pytest
 from hamcrest import *
 
 from autokey.scripting import Window
+from autokey.scripting.window import XRANDR_MONITOR_REGEX, WMCTRL_GEOM_REGEX
+
+import re
+
+wmctrl_out_1 = """0x04c00007  0 2164 608  752  599  samdesktop System Monitor
+0x05600007  0 660  209  960  540  samdesktop AutoKey"""
+
+wmctrl_out_2 = """0x02a00003  0 0    0    1920 1056 samdesktop Add more functions to window API by sebastiansam55 · Pull Request #471 · autokey/autokey — Mozilla Firefox
+0x02a0004d  1 574  301  720  583  samdesktop (2702) Best of the Worst: Wheel of the Worst #20 - YouTube — Mozilla Firefox
+0x04000007  1 2371 319  578  350  samdesktop Bluetooth Devices
+0x04400004  0 3840 0    1440 876  samdesktop tmux /home/sam"""
+
+wmctrl_out_3 = """0x07005700  0 60   132  1288 550  samdesktop craigslist
+0x04c00004  0 725  241  800  600  samdesktop wmctrl /home/sam
+0x08800007  0 228  234  652  579  samdesktop wmctrl-1.07.tar.gz [read only]
+0x070201c3  0 200  272  1288 550  samdesktop wmctrl-1.07
+0x08a000f8  0 418  424  952  799  samdesktop main.c (~/Applications/wmctrl-1.07) - gedit
+0x08c00007  0 1980 132  960  540  samdesktop AutoKey"""
+
+wmctrl_popen_out = b"""0x08a000f8  0 418  424  952  799  samdesktop main.c (~/Applications/wmctrl-1.07) - gedit
+0x08c00007  0 1980 132  960  540  samdesktop AutoKey
+"""
+
+get_window_list_output_1 = [
+    ("0x07200007", "0", "samdesktop", "AutoKey"),
+    ("0x02000007", "0", "samdesktop", "Desktop"),
+    ("0x08008500", "0", "samdesktop", "Firefox"),
+    ("0x08c00007", "0", "samdesktop", "AutoKey")
+]
+
+# get_window_list_output_2 = 
 
 def create_window():
     win = Window(MagicMock())
@@ -20,6 +52,11 @@ def test_window_activate():
     pass
 
 def test_window_close():
+    # is there an easy way to determine what the "signal" sent is?
+    # looking at the wmctrl source code it sends _NET_CLOSE_WINDOW
+    # which seems to just tell the window manager that the window should close
+    # My initial impression reading the documentation was that wmctrl
+    # was sending a "signal" like SIGKILL or SIGTERM
     pass
 
 def test_window_resize_move():
@@ -31,88 +68,112 @@ def test_window_move_to_desktop():
 def test_window_switch_desktop():
     pass
 
+
 def test_window_set_property():
     pass
 
+# @pytest.mark.parametrize("", [])
 def test_window_get_active_geometry():
+    # this function is a wrapper of get_window_geometry
+    # it is covered by the tests for that function
     pass
 
+# @pytest.mark.parametrize("", [])
 def test_window_get_active_title():
     pass
 
+# @pytest.mark.parametrize("", [])
 def test_window_get_active_class():
     pass
 
-       #Monitors: 2
-        # 0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
-        # 1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0
+
+
+
+#xrandr output:
+####
+#$ xrandr --listactivemonitors
+#Monitors: 2
+# 0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
+# 1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0
+####
+# Notes: "Monitors" is always plural
+# the asterik denotes the primary monitor
+# 0: +*HDMI-0 1920/521x1080/293+0+0
+#             ^^^^     ^^^^     ^ ^
+# This is output from a 1920x1080 monitor
+# the two zeros at the end represent the x and y offset from origin
+# since this is the primary display they are both zero
 xrandr_raw_double = """Monitors: 2
  0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
  1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0"""
 xrandr_raw_single = """Monitors: 1
  0: +*DVI-D-0 1440/408x900/255+0+0  DVI-D-0"""
 
-@pytest.mark.parametrize("title, xrandr_raw_output, matchClass", [
-    (None, (0, xrandr_raw_single), False), #single monitor
-    (None, (0, xrandr_raw_double), False), #double monitor
-    (":ACTIVE:", (0, xrandr_raw_double), False),
-    ("AutoKey", (0, xrandr_raw_double), False),
+@pytest.mark.parametrize("title, xrandr_raw_output, matchClass, by_hex", [
+    (None, (0, xrandr_raw_single), False, False), #single monitor
+    (None, (0, xrandr_raw_double), False, False), #double monitor
+    (":ACTIVE:", (0, xrandr_raw_double), False, False),
+    ("AutoKey", (0, xrandr_raw_double), False, False),
 ])
-def test_window_center_window(title, xrandr_raw_output, matchClass):
+def test_window_center_window(title, xrandr_raw_output, matchClass, by_hex):
     window = create_window()
     xrandr = MagicMock(return_value = xrandr_raw_output)
-    with patch("autokey.scripting.window.Window.set_property") as set_prop:
-        with patch("autokey.scripting.window.Window.resize_move") as resize_move:
-            with patch("autokey.scripting.window.Window._run_xrandr", xrandr) as randr:
+    with patch("autokey.scripting.window.Window.set_property") as set_prop, \
+        patch("autokey.scripting.window.Window.resize_move") as resize_move, \
+        patch("autokey.scripting.window.Window._run_xrandr", xrandr) as randr:
                 window.center_window(title)
                 # called with only checks the last time the method was called
                 # set_prop.assert_called_with(title, "remove", "maximized_vert", matchClass=matchClass)
                 # resize_move.assert_called_with(title, , , , )
-                set_prop.assert_called_with(title, "remove", "maximized_horz", matchClass=matchClass)
+                set_prop.assert_called_with(title, "remove", "maximized_horz", matchClass=matchClass, by_hex=by_hex)
+
+
+
+
+@pytest.mark.parametrize("xrandr_output, regex_matches", [
+    (xrandr_raw_single, [("1440", "900", "0", "0")]),
+    (xrandr_raw_double, [("1920", "1080", "0", "0"),("1440", "900", "1920", "0")])
+])
+def test_xrandr_regex(xrandr_output, regex_matches):
+    # there are 4 capture groups, in order from left to right
+    # 1. width of monitor
+    # 2. height of monitor
+    # 3. x offset of monitor
+    # 4. y offset of monitor
+    # Below illustrates the intended captures
+    # 0: +*HDMI-0 1920/521x1080/293+0+0
+    #             ^^^^     ^^^^     ^ ^
+    matches = re.findall(XRANDR_MONITOR_REGEX, xrandr_output, re.MULTILINE)
+    assert matches == regex_matches
+
+
+
 
 @pytest.mark.parametrize("wmctrl_output, func_output", [
-    (
-        (0, """0x02000007  0 samdesktop Desktop
-0x0200000f  0 samdesktop nemo-desktop"""),
-    [
-        ("0x02000007","0","samdesktop", "Desktop"),
-        ("0x0200000f", "0" ,"samdesktop", "nemo-desktop")
-    ]
-)])
+    ((0, wmctrl_out_1), [
+        ("0x04c00007", "0", "samdesktop", "System Monitor"),
+        ("0x05600007", "0", "samdesktop", "AutoKey")
+    ]),
+
+])
 def test_window_get_window_list(wmctrl_output, func_output):
-    print(wmctrl_output)
-    #Example output of
-    #$ wmctrl -l
-    #0x02000007  0 samdesktop Desktop
-    #0x0200000f  0 samdesktop nemo-desktop
-    #0x02a00003  0 samdesktop Add more functions to window API by sebastiansam55 · Pull Request #471 · autokey/autokey — Mozilla Firefox
-    #0x02a0004d  1 samdesktop (2698) Best of the Worst: Wheel of the Worst #20 - YouTube — Mozilla Firefox
-    #0x04000007  1 samdesktop Bluetooth Devices
-    #0x04400004  0 samdesktop tmux /home/sam
-    #0x06600004  0 samdesktop python3 /home/sam/git/ak-fork/lib
-    #0x0700000a  0 samdesktop Downloads
-    #0x07c00003  0 samdesktop Find Results (autokey)
-    #0x07800004  0 samdesktop wmctrl /home/sam
-    #0x08400014  0 samdesktop ak-fork - [~/git/ak-fork]
-    #0x07200007  0 samdesktop AutoKey
-    ########
-    # Each line consists of 4 items in order
-    #1. hexid - Hex identifier of the window used by other methods
-    #2. desktop - Which "desktop" (currently called workspaces in Ubuntu 20.04)
-    #3. hostname - Hostname of the computer the window is located on (?)
-    #   Not sure exactly what charaters are allowed in the hostname
-    #4. title - Title of the window
+    #the same wmctrl command is used for this function and get_window_geometry
+    #see tests for get_window_geometry for more details on the regex used
     window = create_window()
     wmctrl = MagicMock(return_value = wmctrl_output)
     with patch("autokey.scripting.window.Window._run_wmctrl", wmctrl):
+        print("func:",func_output)
+        print("winoutput:",window.get_window_list())
         assert func_output == window.get_window_list()
+
+
 
 
 @pytest.mark.parametrize("title, func_output, get_window_list_output",[
     ("AutoKey", "0x07200007", [("0x07200007", "0", "samdesktop", "AutoKey"),("0x02000007", "0", "samdesktop", "Desktop")]),
+    ("Not Found", None, get_window_list_output_1)
 ])
 def test_window_get_window_hex(title, func_output, get_window_list_output):
-    #TODO there is probably some way to not have to write this at the top of every function
     window = create_window()
     get_window = MagicMock(return_value = get_window_list_output)
     with patch("autokey.scripting.window.Window.get_window_list", get_window):
@@ -120,13 +181,17 @@ def test_window_get_window_hex(title, func_output, get_window_list_output):
         # get_window.assert_called_with()
 
 
-@pytest.mark.parametrize("hexid, wmctrl_output, expected", [
-    ("0x02a0004d", (0, """0x02a00003  0 0    0    1920 1056 samdesktop Add more functions to window API by sebastiansam55 · Pull Request #471 · autokey/autokey — Mozilla Firefox
-0x02a0004d  1 574  301  720  583  samdesktop (2702) Best of the Worst: Wheel of the Worst #20 - YouTube — Mozilla Firefox
-0x04000007  1 2371 319  578  350  samdesktop Bluetooth Devices
-0x04400004  0 3840 0    1440 876  samdesktop tmux /home/sam"""), [574,301,720,583]),
+
+
+@pytest.mark.parametrize("window_title, by_hex, wmctrl_output, expected, active_title, hexid", [
+    ("Bluetooth Devices", False, (0, wmctrl_out_2), [2371, 319, 578, 350], None, None),
+    (":ACTIVE:",          False, (0, wmctrl_out_2), [3840, 0, 1440, 876], "tmux /home/sam", None),
+    ("Cannot be found",   False, (0, wmctrl_out_3), None, None, None),
+    ("String",            True,  (0, wmctrl_out_2), None, None, None),
+    (":ACTIVE:",          True,  (0, wmctrl_out_2), [2371, 319, 578, 350], "Bluetooth Devices", "0x04000007"),
+    ("0x04400004",        True,  (0, wmctrl_out_2), [3840, 0, 1440, 876], None, None),
 ])
-def test_window_get_window_geom(hexid, wmctrl_output, expected):
+def test_window_get_window_geometry(window_title, by_hex, wmctrl_output, expected, active_title, hexid):
     #Example Output:
     #$ wmctrl -lG
     #0x02a00003  0 0    0    1920 1056 samdesktop Add more functions to window API by sebastiansam55 · Pull Request #471 · autokey/autokey — Mozilla Firefox
@@ -146,17 +211,45 @@ def test_window_get_window_geom(hexid, wmctrl_output, expected):
     #hexid, desktop, offsetx, offsety, sizex, sizey, hostname, window_title
     window = create_window()
     wmctrl = MagicMock(return_value = wmctrl_output)
-    with patch("autokey.scripting.window.Window._run_wmctrl", wmctrl) as get_win_geom:
-        assert expected == window.get_window_geom(hexid)
+    get_active = MagicMock(return_value = active_title)
+    hex_fetch = MagicMock(return_value = hexid)
+    with patch("autokey.scripting.window.Window._run_wmctrl", wmctrl) as get_win_geometry, \
+         patch("autokey.scripting.window.Window.get_active_title", get_active) as get_active_title, \
+         patch("autokey.scripting.window.Window.get_window_hex", hex_fetch) as get_window_hex:
+        assert expected == window.get_window_geometry(window_title, by_hex)
+        if window_title == ":ACTIVE:":
+            get_active_title.assert_called()
 
 
-@pytest.mark.parametrize("wm_args, output",[
-    ([], ""),
+
+@pytest.mark.parametrize("args, wmctrl_output, clean_output",[
+    (["-l"], (b'output', b''), "outpu"),
+    (["-lG"], (wmctrl_popen_out, b""), wmctrl_popen_out.decode()[:-1]),
 ])
-def test_window__run_wmctrl(wm_args, output):
+def test_window__run_wmctrl(args, wmctrl_output, clean_output):
     window = create_window()
+    # via https://stackoverflow.com/questions/53784239/python-unit-testing-mocking-popen-and-popen-communicate
     popen = MagicMock()
+    # popen returns as bytes and returns a tuple in form of (stdout_data, stderr_data)
+    popen.return_value.__enter__.return_value.communicate.return_value = wmctrl_output
+    popen.return_value.__enter__.return_value.returncode = 0
+    with patch("subprocess.Popen", popen), patch("subprocess.PIPE"):
+        output = window._run_wmctrl(args)
+        assert len(output) == 2
+        # _run_wmctrl decodes bytes to string and strips the last character (usually a newline)
+        assert output[1] == clean_output
+        assert type(output[1]) == str
+        assert output[0] == 0
+
+def test_window__run_wmctrl_not_found():
+    window = create_window()
+    popen = MagicMock(side_effect=FileNotFoundError)
     with patch("subprocess.Popen", popen):
-        output = window._run_wmctrl(wm_args)
+        assert window._run_wmctrl(["-lG"]) == (1, "ERROR: Please install wmctrl")
 
 
+def test_window__run_xrandr_not_found():
+    window = create_window()
+    popen = MagicMock(side_effect=FileNotFoundError)
+    with patch("subprocess.Popen", popen):
+        assert window._run_xrandr(["--listactivemonitors"]) == (1, "ERROR: Please install xrandr")

--- a/tests/scripting_api/test_window.py
+++ b/tests/scripting_api/test_window.py
@@ -1,0 +1,162 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hamcrest import *
+
+from autokey.scripting import Window
+
+def create_window():
+    win = Window(MagicMock())
+    return win
+
+def test_window_wait_for_focus() -> Window:
+    #TODO tests
+    pass
+
+def test_window_wait_for_exist():
+    pass
+
+def test_window_activate():
+    pass
+
+def test_window_close():
+    pass
+
+def test_window_resize_move():
+    pass
+
+def test_window_move_to_desktop():
+    pass
+
+def test_window_switch_desktop():
+    pass
+
+def test_window_set_property():
+    pass
+
+def test_window_get_active_geometry():
+    pass
+
+def test_window_get_active_title():
+    pass
+
+def test_window_get_active_class():
+    pass
+
+       #Monitors: 2
+        # 0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
+        # 1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0
+xrandr_raw_double = """Monitors: 2
+ 0: +*HDMI-0 1920/521x1080/293+0+0  HDMI-0
+ 1: +DVI-D-0 1440/408x900/255+1920+0  DVI-D-0"""
+xrandr_raw_single = """Monitors: 1
+ 0: +*DVI-D-0 1440/408x900/255+0+0  DVI-D-0"""
+
+@pytest.mark.parametrize("title, xrandr_raw_output, matchClass", [
+    (None, (0, xrandr_raw_single), False), #single monitor
+    (None, (0, xrandr_raw_double), False), #double monitor
+    (":ACTIVE:", (0, xrandr_raw_double), False),
+    ("AutoKey", (0, xrandr_raw_double), False),
+])
+def test_window_center_window(title, xrandr_raw_output, matchClass):
+    window = create_window()
+    xrandr = MagicMock(return_value = xrandr_raw_output)
+    with patch("autokey.scripting.window.Window.set_property") as set_prop:
+        with patch("autokey.scripting.window.Window.resize_move") as resize_move:
+            with patch("autokey.scripting.window.Window._run_xrandr", xrandr) as randr:
+                window.center_window(title)
+                # called with only checks the last time the method was called
+                # set_prop.assert_called_with(title, "remove", "maximized_vert", matchClass=matchClass)
+                # resize_move.assert_called_with(title, , , , )
+                set_prop.assert_called_with(title, "remove", "maximized_horz", matchClass=matchClass)
+
+@pytest.mark.parametrize("wmctrl_output, func_output", [
+    (
+        (0, """0x02000007  0 samdesktop Desktop
+0x0200000f  0 samdesktop nemo-desktop"""),
+    [
+        ("0x02000007","0","samdesktop", "Desktop"),
+        ("0x0200000f", "0" ,"samdesktop", "nemo-desktop")
+    ]
+)])
+def test_window_get_window_list(wmctrl_output, func_output):
+    print(wmctrl_output)
+    #Example output of
+    #$ wmctrl -l
+    #0x02000007  0 samdesktop Desktop
+    #0x0200000f  0 samdesktop nemo-desktop
+    #0x02a00003  0 samdesktop Add more functions to window API by sebastiansam55 · Pull Request #471 · autokey/autokey — Mozilla Firefox
+    #0x02a0004d  1 samdesktop (2698) Best of the Worst: Wheel of the Worst #20 - YouTube — Mozilla Firefox
+    #0x04000007  1 samdesktop Bluetooth Devices
+    #0x04400004  0 samdesktop tmux /home/sam
+    #0x06600004  0 samdesktop python3 /home/sam/git/ak-fork/lib
+    #0x0700000a  0 samdesktop Downloads
+    #0x07c00003  0 samdesktop Find Results (autokey)
+    #0x07800004  0 samdesktop wmctrl /home/sam
+    #0x08400014  0 samdesktop ak-fork - [~/git/ak-fork]
+    #0x07200007  0 samdesktop AutoKey
+    ########
+    # Each line consists of 4 items in order
+    #1. hexid - Hex identifier of the window used by other methods
+    #2. desktop - Which "desktop" (currently called workspaces in Ubuntu 20.04)
+    #3. hostname - Hostname of the computer the window is located on (?)
+    #   Not sure exactly what charaters are allowed in the hostname
+    #4. title - Title of the window
+    window = create_window()
+    wmctrl = MagicMock(return_value = wmctrl_output)
+    with patch("autokey.scripting.window.Window._run_wmctrl", wmctrl):
+        assert func_output == window.get_window_list()
+
+
+@pytest.mark.parametrize("title, func_output, get_window_list_output",[
+    ("AutoKey", "0x07200007", [("0x07200007", "0", "samdesktop", "AutoKey"),("0x02000007", "0", "samdesktop", "Desktop")]),
+])
+def test_window_get_window_hex(title, func_output, get_window_list_output):
+    #TODO there is probably some way to not have to write this at the top of every function
+    window = create_window()
+    get_window = MagicMock(return_value = get_window_list_output)
+    with patch("autokey.scripting.window.Window.get_window_list", get_window):
+        assert func_output == window.get_window_hex(title)
+        # get_window.assert_called_with()
+
+
+@pytest.mark.parametrize("hexid, wmctrl_output, expected", [
+    ("0x02a0004d", (0, """0x02a00003  0 0    0    1920 1056 samdesktop Add more functions to window API by sebastiansam55 · Pull Request #471 · autokey/autokey — Mozilla Firefox
+0x02a0004d  1 574  301  720  583  samdesktop (2702) Best of the Worst: Wheel of the Worst #20 - YouTube — Mozilla Firefox
+0x04000007  1 2371 319  578  350  samdesktop Bluetooth Devices
+0x04400004  0 3840 0    1440 876  samdesktop tmux /home/sam"""), [574,301,720,583]),
+])
+def test_window_get_window_geom(hexid, wmctrl_output, expected):
+    #Example Output:
+    #$ wmctrl -lG
+    #0x02a00003  0 0    0    1920 1056 samdesktop Add more functions to window API by sebastiansam55 · Pull Request #471 · autokey/autokey — Mozilla Firefox
+    #0x02a0004d  1 574  301  720  583  samdesktop (2702) Best of the Worst: Wheel of the Worst #20 - YouTube — Mozilla Firefox
+    #0x04000007  1 2371 319  578  350  samdesktop Bluetooth Devices
+    #0x04400004  0 3840 0    1440 876  samdesktop tmux /home/sam
+    #0x06600004  0 1023 187  800  600  samdesktop python3 /home/sam/git/ak-fork/lib
+    #0x0700000a  0 76   142  1288 550  samdesktop Downloads
+    #0x07800004  0 2141 223  800  600  samdesktop fish /home/sam
+    #0x08e000f8  0 534  654  952  799  samdesktop *Untitled Document 1 - gedit
+    #0x07200007  0 104  176  960  540  samdesktop AutoKey
+    #0x04e00192  0 1618 428  300  650         N/A N/A
+    #0x02000485  0 3840 0    1440 900  samdesktop Desktop
+    #0x02000489  0 0    0    1920 1080 samdesktop nemo-desktop
+    #0x0a200004  0 60   132  800  600  samdesktop fish /home/sam
+    #Where the values are;
+    #hexid, desktop, offsetx, offsety, sizex, sizey, hostname, window_title
+    window = create_window()
+    wmctrl = MagicMock(return_value = wmctrl_output)
+    with patch("autokey.scripting.window.Window._run_wmctrl", wmctrl) as get_win_geom:
+        assert expected == window.get_window_geom(hexid)
+
+
+@pytest.mark.parametrize("wm_args, output",[
+    ([], ""),
+])
+def test_window__run_wmctrl(wm_args, output):
+    window = create_window()
+    popen = MagicMock()
+    with patch("subprocess.Popen", popen):
+        output = window._run_wmctrl(wm_args)
+
+


### PR DESCRIPTION
Adds `get_window_geom`, `get_window_hex` and `get_window_list` to the window API. Allows for use of other commands like `import -window <hexid>` for getting screenshots of windows (for upcoming visgrep changes). 