### PR TITLE
[Qt] Use system set monospace font

### DIFF
--- a/lib/autokey/qtui/common.py
+++ b/lib/autokey/qtui/common.py
@@ -21,7 +21,7 @@ import enum
 import functools
 
 from PyQt5.QtCore import QFile, QSize
-from PyQt5.QtGui import QFont, QIcon, QPixmap, QPainter, QColor
+from PyQt5.QtGui import QFont, QIcon, QPixmap, QPainter, QColor, QFontDatabase
 from PyQt5.QtWidgets import QMessageBox, QLabel
 from PyQt5 import uic
 from PyQt5.QtSvg import QSvgRenderer
@@ -63,8 +63,9 @@ def monospace_font() -> QFont:
     Returns a monospace font used in the code editor widgets.
     :return: QFont instance having a monospace font.
     """
-    font = QFont("monospace")
-    font.setStyleHint(QFont.Monospace)
+    font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+    # font = QFont("monospace")
+    # font.setStyleHint(QFont.Monospace)
     return font
 
 


### PR DESCRIPTION
Fix for #474 swap from using the first "monospace" font returned by QFont to the system default font.