### PR TITLE
Add alt_gr as an option when setting hotkeys

### DIFF
--- a/lib/autokey/gtkui/data/hotkeysettings.xml
+++ b/lib/autokey/gtkui/data/hotkeysettings.xml
@@ -106,6 +106,21 @@
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkToggleButton" id="altgrButton">
+                    <property name="label" translatable="yes">Alt GR</property>
+                    <property name="use_action_appearance">False</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="use_action_appearance">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkToggleButton" id="shiftButton">
                     <property name="label" translatable="yes">Shift</property>
                     <property name="use_action_appearance">False</property>
@@ -117,7 +132,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
@@ -132,7 +147,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
                 <child>
@@ -147,7 +162,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">4</property>
+                    <property name="position">5</property>
                   </packing>
                 </child>
                 <child>
@@ -162,7 +177,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">5</property>
+                    <property name="position">6</property>
                   </packing>
                 </child>
               </object>

--- a/lib/autokey/gtkui/dialogs.py
+++ b/lib/autokey/gtkui/dialogs.py
@@ -430,6 +430,7 @@ class HotkeySettingsDialog(DialogBase):
 
         self.controlButton = builder.get_object("controlButton")
         self.altButton = builder.get_object("altButton")
+        self.altgrButton = builder.get_object("altgrButton")
         self.shiftButton = builder.get_object("shiftButton")
         self.superButton = builder.get_object("superButton")
         self.hyperButton = builder.get_object("hyperButton")
@@ -445,6 +446,7 @@ class HotkeySettingsDialog(DialogBase):
         if autokey.model.helpers.TriggerMode.HOTKEY in item.modes:
             self.controlButton.set_active(Key.CONTROL in item.modifiers)
             self.altButton.set_active(Key.ALT in item.modifiers)
+            self.altgrButton.set_active(Key.ALT_GR in item.modifiers)
             self.shiftButton.set_active(Key.SHIFT in item.modifiers)
             self.superButton.set_active(Key.SUPER in item.modifiers)
             self.hyperButton.set_active(Key.HYPER in item.modifiers)
@@ -479,6 +481,7 @@ class HotkeySettingsDialog(DialogBase):
     def reset(self):
         self.controlButton.set_active(False)
         self.altButton.set_active(False)
+        self.altgrButton.set_active(False)
         self.shiftButton.set_active(False)
         self.superButton.set_active(False)
         self.hyperButton.set_active(False)
@@ -498,6 +501,7 @@ class HotkeySettingsDialog(DialogBase):
         self.key = key
         self.controlButton.set_active(Key.CONTROL in modifiers)
         self.altButton.set_active(Key.ALT in modifiers)
+        self.altgrButton.set_active(Key.ALT_GR in modifiers)
         self.shiftButton.set_active(Key.SHIFT in modifiers)
         self.superButton.set_active(Key.SUPER in modifiers)
         self.hyperButton.set_active(Key.HYPER in modifiers)
@@ -518,6 +522,8 @@ class HotkeySettingsDialog(DialogBase):
             modifiers.append(Key.CONTROL)
         if self.altButton.get_active():
             modifiers.append(Key.ALT)
+        if self.altgrButton.get_active():
+            modifiers.append(Key.ALT_GR)
         if self.shiftButton.get_active():
             modifiers.append(Key.SHIFT)
         if self.superButton.get_active():
@@ -553,6 +559,7 @@ class GlobalHotkeyDialog(HotkeySettingsDialog):
         if item.enabled:
             self.controlButton.set_active(Key.CONTROL in item.modifiers)
             self.altButton.set_active(Key.ALT in item.modifiers)
+            self.altgrButton.set_active(Key.ALT_GR in item.modifiers)
             self.shiftButton.set_active(Key.SHIFT in item.modifiers)
             self.superButton.set_active(Key.SUPER in item.modifiers)
             self.hyperButton.set_active(Key.HYPER in item.modifiers)

--- a/lib/autokey/model/key.py
+++ b/lib/autokey/model/key.py
@@ -121,4 +121,5 @@ _ALL_MODIFIERS_ = (
 KEY_FIND_RE = re.compile("|".join(("|".join(Key), _code_point_re.pattern)), re.UNICODE)
 KEY_SPLIT_RE = re.compile("(<[^<>]+>\+?)")
 MODIFIERS = [Key.CONTROL, Key.ALT, Key.ALT_GR, Key.SHIFT, Key.SUPER, Key.HYPER, Key.META, Key.CAPSLOCK, Key.NUMLOCK]
-HELD_MODIFIERS = [Key.CONTROL, Key.ALT, Key.SUPER, Key.SHIFT, Key.HYPER, Key.META]
+HELD_MODIFIERS = [Key.CONTROL, Key.ALT_GR, Key.ALT, Key.SUPER, Key.SHIFT, Key.HYPER, Key.META
+]


### PR DESCRIPTION
Tested using `xmodmap` to remap rightmeta to `ISO_Level3_Shift` (`AltGr`). Fix for #366. Picture of change in UI attached. Works as expected in combination with other modifier keys.


![Screenshot from 2020-11-20 08-06-30](https://user-images.githubusercontent.com/1707320/99803370-55d94580-2b07-11eb-8960-a5b0260cfe5e.png)
