### PR TITLE
Adds listener to __flushEvents in interface.py to catch MappingNotify events...

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -223,9 +223,10 @@ class XInterfaceBase(threading.Thread):
         self.__NameAtom = self.localDisplay.intern_atom("_NET_WM_NAME", True)
         self.__VisibleNameAtom = self.localDisplay.intern_atom("_NET_WM_VISIBLE_NAME", True)
         
-        if not common.USING_QT:
-            self.keyMap = Gdk.Keymap.get_default()
-            self.keyMap.connect("keys-changed", self.on_keys_changed)
+        #move detection of key map changes to X event thread in order to have QT and GTK detection
+        # if not common.USING_QT:
+            # self.keyMap = Gdk.Keymap.get_default()
+            # self.keyMap.connect("keys-changed", self.on_keys_changed)
         
         self.__ignoreRemap = False
         
@@ -916,6 +917,9 @@ class XInterfaceBase(threading.Thread):
                             createdWindows.append(event.window)
                         if event.type == X.DestroyNotify:
                             destroyedWindows.append(event.window)
+                        if event.type == X.MappingNotify:
+                            logger.debug("X Mapping Event Detected")
+                            self.on_keys_changed()
                             
                     for window in createdWindows:
                         if window not in destroyedWindows:


### PR DESCRIPTION
sent from X instead of relying on the GDK library for it (now both Qt and Gtk versions will reload hotkeys after a keymap change event, fixes #278 ). Tested using `xdotool` because that also seems to send `MappingNotify` events when using a key not on your keymap.

- `MappingNotify` event: https://python-xlib.github.io/python-xlib_12.html#Event-Types