### PR TITLE
Develop lock/unlock fix

### DIFF
--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -213,7 +213,8 @@ class Service:
 
     def __tryReleaseLock(self):
         try:
-            self.configManager.lock.release()
+            if self.configManager.lock.locked():
+                self.configManager.lock.release()
         except:
             logger.exception("Ignored locking error in handle_keypress")
 


### PR DESCRIPTION
There are a number of ways to fix this error from popping up. In the original `handle_keypress` the lock is released after processing any matching items and the method attempts to release the lock again at the end of the method, in order to make sure the thread is unlocked. 

This can be fixed by reacquiring the lock immediately after lock has been released and item processed. See https://github.com/sebastiansam55/autokey/commit/b655b0b0f44c570928d22ce1cd4f2b416095383f

The way that this PR fixes the issue is to check if the lock is locked before trying to release it.