### PR TITLE
Develop json link

### DIFF
--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -62,7 +62,7 @@ PROBLEM_MSG_SECONDARY = _("%s\n\nYour changes have not been saved.")
 from .configwindow0 import get_ui
 
 
-def set_linkbutton(button, path):
+def set_linkbutton(button, path, filename_only=False):
     button.set_sensitive(True)
 
     if path.startswith(cm_constants.CONFIG_DEFAULT_FOLDER):
@@ -70,7 +70,10 @@ def set_linkbutton(button, path):
     else:
         text = path.replace(os.path.expanduser("~"), "~")
 
-    button.set_label(text)
+    if filename_only:
+        button.set_label(path[path.rindex("/")+1:])
+    else:
+        button.set_label(text)
     button.set_uri("file://" + path)
     label = button.get_child()
     label.set_ellipsize(Pango.EllipsizeMode.START)
@@ -350,8 +353,12 @@ class FolderPage:
 
         self.showInTrayCheckbox = builder.get_object("showInTrayCheckbox")
         self.linkButton = builder.get_object("linkButton")
+        self.jsonLinkButton = builder.get_object("linkButton1")
         label = self.linkButton.get_child()
         label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
+
+        label1 = self.jsonLinkButton.get_child()
+        label1.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
 
         vbox = builder.get_object("settingsVbox")
         self.settingsWidget = SettingsWidget(parentWindow)
@@ -365,8 +372,11 @@ class FolderPage:
         if self.is_new_item():
             self.linkButton.set_sensitive(False)
             self.linkButton.set_label(_("(Unsaved)"))
+            self.jsonLinkButton.set_sensitive(False)
+            self.jsonLinkButton.set_label(_("(Unsaved)"))
         else:
             set_linkbutton(self.linkButton, self.currentFolder.path)
+            set_linkbutton(self.jsonLinkButton, self.currentFolder.get_json_path(), True)
 
     def save(self):
         self.currentFolder.show_in_tray_menu = self.showInTrayCheckbox.get_active()
@@ -436,8 +446,12 @@ class ScriptPage:
         self.promptCheckbox = builder.get_object("promptCheckbox")
         self.showInTrayCheckbox = builder.get_object("showInTrayCheckbox")
         self.linkButton = builder.get_object("linkButton")
+        self.jsonLinkButton = builder.get_object("linkButton1")
         label = self.linkButton.get_child()
         label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
+
+        label1 = self.jsonLinkButton.get_child()
+        label1.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
 
         vbox = builder.get_object("settingsVbox")
         self.settingsWidget = SettingsWidget(parentWindow)
@@ -471,8 +485,11 @@ class ScriptPage:
         if self.is_new_item():
             self.linkButton.set_sensitive(False)
             self.linkButton.set_label(_("(Unsaved)"))
+            self.jsonLinkButton.set_sensitive(False)
+            self.jsonLinkButton.set_label(_("(Unsaved)"))
         else:
             set_linkbutton(self.linkButton, self.currentItem.path)
+            set_linkbutton(self.jsonLinkButton, self.currentItem.get_json_path(), True)
 
     def save(self):
         self.currentItem.code = self.buffer.get_text(self.buffer.get_start_iter(), self.buffer.get_end_iter(), False)
@@ -608,6 +625,7 @@ class PhrasePage(ScriptPage):
         sendModeHbox.pack_start(self.sendModeCombo, False, False, 0)
 
         self.linkButton = builder.get_object("linkButton")
+        self.jsonLinkButton = builder.get_object("linkButton1")
 
         vbox = builder.get_object("settingsVbox")
         self.settingsWidget = SettingsWidget(parentWindow)
@@ -652,8 +670,11 @@ class PhrasePage(ScriptPage):
         if self.is_new_item():
             self.linkButton.set_sensitive(False)
             self.linkButton.set_label(_("(Unsaved)"))
+            self.jsonLinkButton.set_sensitive(False)
+            self.jsonLinkButton.set_label(_("(Unsaved)"))
         else:
             set_linkbutton(self.linkButton, self.currentItem.path)
+            set_linkbutton(self.jsonLinkButton, self.currentItem.get_json_path(), True)
 
         l = list(autokey.model.phrase.SEND_MODES.keys())
         l.sort()

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -71,9 +71,11 @@ def set_linkbutton(button, path, filename_only=False):
         text = path.replace(os.path.expanduser("~"), "~")
 
     if filename_only:
-        button.set_label(path[path.rindex("/")+1:])
+        filename = os.path.basename(path)
+        button.set_label(filename)
     else:
         button.set_label(text)
+
     button.set_uri("file://" + path)
     label = button.get_child()
     label.set_ellipsize(Pango.EllipsizeMode.START)
@@ -353,7 +355,7 @@ class FolderPage:
 
         self.showInTrayCheckbox = builder.get_object("showInTrayCheckbox")
         self.linkButton = builder.get_object("linkButton")
-        self.jsonLinkButton = builder.get_object("linkButton1")
+        self.jsonLinkButton = builder.get_object("jsonLinkButton")
         label = self.linkButton.get_child()
         label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
 
@@ -446,7 +448,7 @@ class ScriptPage:
         self.promptCheckbox = builder.get_object("promptCheckbox")
         self.showInTrayCheckbox = builder.get_object("showInTrayCheckbox")
         self.linkButton = builder.get_object("linkButton")
-        self.jsonLinkButton = builder.get_object("linkButton1")
+        self.jsonLinkButton = builder.get_object("jsonLinkButton")
         label = self.linkButton.get_child()
         label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
 
@@ -625,7 +627,7 @@ class PhrasePage(ScriptPage):
         sendModeHbox.pack_start(self.sendModeCombo, False, False, 0)
 
         self.linkButton = builder.get_object("linkButton")
-        self.jsonLinkButton = builder.get_object("linkButton1")
+        self.jsonLinkButton = builder.get_object("jsonLinkButton")
 
         vbox = builder.get_object("settingsVbox")
         self.settingsWidget = SettingsWidget(parentWindow)

--- a/lib/autokey/gtkui/data/folderpage.xml
+++ b/lib/autokey/gtkui/data/folderpage.xml
@@ -13,21 +13,42 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <object class="GtkLinkButton" id="linkButton">
-            <property name="label" translatable="yes">(Unsaved)</property>
-            <property name="use_action_appearance">False</property>
+          <object class="GtkHBox" id="linkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="has_tooltip">True</property>
-            <property name="use_action_appearance">False</property>
-            <property name="relief">none</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLinkButton" id="linkButton">
+                <property name="label" translatable="yes">(Unsaved)</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="has_tooltip">True</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLinkButton" id="linkButton1">
+                <property name="label" translatable="yes">(Unsaved)</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="has_tooltip">True</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkFrame" id="frame1">

--- a/lib/autokey/gtkui/data/folderpage.xml
+++ b/lib/autokey/gtkui/data/folderpage.xml
@@ -33,7 +33,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLinkButton" id="linkButton1">
+              <object class="GtkLinkButton" id="jsonLinkButton">
                 <property name="label" translatable="yes">(Unsaved)</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>

--- a/lib/autokey/gtkui/data/folderpage.xml
+++ b/lib/autokey/gtkui/data/folderpage.xml
@@ -49,6 +49,11 @@
               </packing>
             </child>
           </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
         </child>
         <child>
           <object class="GtkFrame" id="frame1">

--- a/lib/autokey/gtkui/data/phrasepage.xml
+++ b/lib/autokey/gtkui/data/phrasepage.xml
@@ -33,7 +33,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLinkButton" id="linkButton1">
+              <object class="GtkLinkButton" id="jsonLinkButton">
                 <property name="label" translatable="yes">(Unsaved)</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>

--- a/lib/autokey/gtkui/data/phrasepage.xml
+++ b/lib/autokey/gtkui/data/phrasepage.xml
@@ -12,15 +12,43 @@
         <property name="can_focus">False</property>
         <property name="spacing">5</property>
         <child>
-          <object class="GtkLinkButton" id="linkButton">
-            <property name="label" translatable="yes">(Unsaved)</property>
-            <property name="use_action_appearance">False</property>
+          <object class="GtkHBox" id="linkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="has_tooltip">True</property>
-            <property name="use_action_appearance">False</property>
-            <property name="relief">none</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLinkButton" id="linkButton">
+                <property name="label" translatable="yes">(Unsaved)</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="has_tooltip">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLinkButton" id="linkButton1">
+                <property name="label" translatable="yes">(Unsaved)</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="has_tooltip">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/lib/autokey/gtkui/data/scriptpage.xml
+++ b/lib/autokey/gtkui/data/scriptpage.xml
@@ -27,8 +27,8 @@
                 <property name="relief">none</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">0</property>
               </packing>
             </child>
@@ -44,8 +44,8 @@
                 <property name="relief">none</property>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>

--- a/lib/autokey/gtkui/data/scriptpage.xml
+++ b/lib/autokey/gtkui/data/scriptpage.xml
@@ -33,7 +33,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLinkButton" id="linkButton1">
+              <object class="GtkLinkButton" id="jsonLinkButton">
                 <property name="label" translatable="yes">(Unsaved)</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>

--- a/lib/autokey/gtkui/data/scriptpage.xml
+++ b/lib/autokey/gtkui/data/scriptpage.xml
@@ -12,15 +12,43 @@
         <property name="can_focus">False</property>
         <property name="spacing">5</property>
         <child>
-          <object class="GtkLinkButton" id="linkButton">
-            <property name="label" translatable="yes">(Unsaved)</property>
-            <property name="use_action_appearance">False</property>
+          <object class="GtkHBox" id="linkBox">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">True</property>
-            <property name="has_tooltip">True</property>
-            <property name="use_action_appearance">False</property>
-            <property name="relief">none</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLinkButton" id="linkButton">
+                <property name="label" translatable="yes">(Unsaved)</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="has_tooltip">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLinkButton" id="linkButton1">
+                <property name="label" translatable="yes">(Unsaved)</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="has_tooltip">True</property>
+                <property name="use_action_appearance">False</property>
+                <property name="relief">none</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Changes pictured below. Adds a link to the JSON config file along side the original link to the file itself. Unlike the `*.txt` or `*.py` it only displays the filename instead of the full path in order to save space.

Implemented because I was sick of navigating manually to the config files when doing debugging.

![Screenshot from 2020-11-27 19-15-29](https://user-images.githubusercontent.com/1707320/100489934-814ec800-30e5-11eb-8fc9-2f07afc815aa.png)
![Screenshot from 2020-11-27 19-15-37](https://user-images.githubusercontent.com/1707320/100489935-83b12200-30e5-11eb-8bfa-0bd26eca39d4.png)
![Screenshot from 2020-11-27 19-15-43](https://user-images.githubusercontent.com/1707320/100489937-857ae580-30e5-11eb-899b-e5776b2413bc.png)
