### PR TITLE
[Gtk] Ensure proper python libraries and command line programs AutoKey relies on are installed before launching

### DIFF
--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -7,13 +7,13 @@ logger = __import__("autokey.logger").logger.get_logger(__name__)
 common_modules = ['argparse', 'collections', 'enum', 'faulthandler', 
             'gettext', 'inspect', 'itertools', 'logging', 'os', 'select', 'shlex',
             'shutil', 'subprocess', 'sys', 'threading', 'time', 'traceback', 'typing',
-            'warnings', 'webbrowser', 'dbus', 'pyinotify', "asddgs"]
+            'warnings', 'webbrowser', 'dbus', 'pyinotify']
 gtk_modules = ['gi', 'gi.repository.Gtk', 'gi.repository.Gdk', 'gi.repository.Pango',
             'gi.repository.Gio', 'gi.repository.GtkSource']
 qt_modules = ['PyQt5', 'PyQt5.QtGui', 'PyQt5.QtWidgets', 'PyQt5.QtCore',
             'PyQt5.Qsci']
 
-common_programs = ['wmctrl', 'ps', "sxvbsd"]
+common_programs = ['wmctrl', 'ps']
 # Checking some of these appears to be redundant as some are provided by the same packages on my system but 
 # better safe than sorry.
 optional_programs = ['visgrep', 'import', 'png2pat', 'xte', 'xmousepos']
@@ -30,20 +30,23 @@ def checkModuleImports(modules):
 
     return missing_modules
 
-def checkProgramImports(programs):
+def checkProgramImports(programs, optional=False):
     missing_programs = []
     for program in programs:
         if which(program) is None:
             # file not found by shell
-            logger.debug("Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
+            if optional:
+                logger.debug("Optional Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
+            else:
+                logger.debug("Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
             missing_programs.append(program)
     return missing_programs
 
 def checkOptionalPrograms():
     if common.USING_QT:
-        checkProgramImports(optional_programs)
+        checkProgramImports(optional_programs, optional=True)
     else:
-        checkProgramImports(optional_programs)
+        checkProgramImports(optional_programs, optional=True)
 
 def getErrorMessage(item_type, missing_items):
     error_message = ""

--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -25,7 +25,7 @@ def checkModuleImports(modules):
     for module in modules:
         spec = importlib.util.find_spec(module)
         if spec is None: #module has not been imported/found correctly
-            logger.debug("Python module: \""+module+"\" was not found/able to be imported correctly on the system check that the module(s) are installed correctly")
+            logger.error("Python module: \""+module+"\" was not found/able to be imported correctly on the system check that the module(s) are installed correctly")
             missing_modules.append(module)
 
     return missing_modules
@@ -36,9 +36,9 @@ def checkProgramImports(programs, optional=False):
         if which(program) is None:
             # file not found by shell
             if optional:
-                logger.debug("Optional Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
+                logger.info("Optional Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
             else:
-                logger.debug("Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
+                logger.error("Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
             missing_programs.append(program)
     return missing_programs
 

--- a/lib/autokey/UI_common_functions.py
+++ b/lib/autokey/UI_common_functions.py
@@ -1,0 +1,64 @@
+import importlib
+from shutil import which
+from . import common
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+common_modules = ['argparse', 'collections', 'enum', 'faulthandler', 
+            'gettext', 'inspect', 'itertools', 'logging', 'os', 'select', 'shlex',
+            'shutil', 'subprocess', 'sys', 'threading', 'time', 'traceback', 'typing',
+            'warnings', 'webbrowser', 'dbus', 'pyinotify', "asddgs"]
+gtk_modules = ['gi', 'gi.repository.Gtk', 'gi.repository.Gdk', 'gi.repository.Pango',
+            'gi.repository.Gio', 'gi.repository.GtkSource']
+qt_modules = ['PyQt5', 'PyQt5.QtGui', 'PyQt5.QtWidgets', 'PyQt5.QtCore',
+            'PyQt5.Qsci']
+
+common_programs = ['wmctrl', 'ps', "sxvbsd"]
+# Checking some of these appears to be redundant as some are provided by the same packages on my system but 
+# better safe than sorry.
+optional_programs = ['visgrep', 'import', 'png2pat', 'xte', 'xmousepos']
+gtk_programs = ['zenity']
+qt_programs = ['kdialog']
+
+def checkModuleImports(modules):
+    missing_modules = []
+    for module in modules:
+        spec = importlib.util.find_spec(module)
+        if spec is None: #module has not been imported/found correctly
+            logger.debug("Python module: \""+module+"\" was not found/able to be imported correctly on the system check that the module(s) are installed correctly")
+            missing_modules.append(module)
+
+    return missing_modules
+
+def checkProgramImports(programs):
+    missing_programs = []
+    for program in programs:
+        if which(program) is None:
+            # file not found by shell
+            logger.debug("Commandline Program: \""+program+"\" was not found/able to be used correctly by AutoKey. Check that this program is correctly installed on your system.")
+            missing_programs.append(program)
+    return missing_programs
+
+def checkOptionalPrograms():
+    if common.USING_QT:
+        checkProgramImports(optional_programs)
+    else:
+        checkProgramImports(optional_programs)
+
+def getErrorMessage(item_type, missing_items):
+    error_message = ""
+    for item in missing_items:
+         error_message+= item_type+": "+item+"\n"
+    return error_message
+
+def checkRequirements():
+    errorMessage = ""
+    if common.USING_QT:
+        missing_programs = checkProgramImports(common_programs+qt_programs)
+        missing_modules = checkModuleImports(common_modules+qt_modules)
+    else:
+        missing_programs = checkProgramImports(common_programs+gtk_programs)
+        missing_modules = checkModuleImports(common_modules+gtk_modules)
+    errorMessage += getErrorMessage("Python Modules",missing_modules)
+    errorMessage += getErrorMessage("Programs",missing_programs)
+    return errorMessage

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -66,6 +66,62 @@ class Application:
         GLib.threads_init()
         Gdk.threads_init()
 
+        #import testing (this wouldn't necessarily catch import errors that happen at the top of this file)
+        # however those are not really the errors we are having issues with
+        # based on this https://docs.python.org/3/py-modindex.html
+        # it is safe to assume that a number of modules will always be available on any
+        # normal python3 installation. This includes re, importlib, subprocess, shutil, sys, os etc. etc.
+        # I guess we will still check for them however because it can't hurt?
+        import importlib
+        from shutil import which
+
+        #these seem to be "default" python modules used by the program
+        python_modules = ['argparse', 'collections', 'enum', 'faulthandler', 
+            'gettext', 'inspect', 'itertools', 'logging', 'os', 'select', 'shlex',
+            'shutil', 'subprocess', 'sys', 'threading', 'time', 'traceback', 'typing',
+            'warnings', 'webbrowser']
+
+        #modules that have to be installed
+        modules = ['Xlib', 'dbus', 'pyinotify']
+
+        #modules specific to gtk
+        gtk_modules = ['gi']
+
+
+        for module in python_modules+modules+gtk_modules:
+            spec = importlib.util.find_spec(module)
+            if spec is None: #module has not been imported/found correctly
+                self.show_error_dialog("Python module: "+module+" has not been imported correctly",
+                    "This python module is required for AutoKey to function properly")
+                sys.exit("Missing python modules")
+            else: 
+                # print(spec)
+                pass
+
+        #test for if command line programs used by AutoKey are installed on the system
+        # visgrep comes from xautomation
+        # import, png2pat from imagemagick.
+        # ps is a command that most if not all systems will have installed fwik
+        # zenity and xdg-open are pretty bog standard gnome/gtk stuff
+
+        linux_programs = ['ps']
+
+        # programs = ['visgrep', 'import', 'png2pat', 'xte', 'wmctrl', 'xmousepos']
+        programs = ['wmctrl']
+
+        gtk_programs = ['zenity']
+
+        for program in linux_programs+programs+gtk_programs:
+            if which(program) is None:
+                # file not found by shell
+                self.show_error_dialog(program+" was not found installed on your system.",
+                    "This program is needed for autokey to function properly")
+                sys.exit("Missing command line program")
+            else:
+                #file was found fine.
+                pass
+
+
         args = autokey.argument_parser.parse_args()
 
         try:

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -278,7 +278,7 @@ class Application:
         @param dialog_type: One of Gtk.MessageType.ERROR, Gtk.MessageType.WARNING , Gtk.MessageType.INFO, Gtk.MessageType.OTHER, Gtk.MessageType.QUESTION
             defaults to Gtk.MessageType.ERROR
         """
-        logger.info("Displaying "+dialog_type.value_name+" Dialog")
+        logger.debug("Displaying "+dialog_type.value_name+" Dialog")
         dlg = Gtk.MessageDialog(type=dialog_type, buttons=Gtk.ButtonsType.OK,
                                  message_format=message)
         if details is not None:

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -70,14 +70,13 @@ class Application:
         args = autokey.argument_parser.parse_args()
         configure_root_logger(args)
 
+        checkOptionalPrograms()
         missing_reqs = checkRequirements()
         if len(missing_reqs)>0:
             Gdk.threads_enter()
             self.show_error_dialog("AutoKey Requires the following programs or python modules to be installed to function properly", missing_reqs)
             Gdk.threads_leave()
             sys.exit("Missing required programs and/or python modules, exiting")
-
-        checkOptionalPrograms()
 
         try:
             # Create configuration directory

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -87,16 +87,11 @@ class Application:
         #modules specific to gtk
         gtk_modules = ['gi']
 
-
+        missing_modules = []
         for module in python_modules+modules+gtk_modules:
             spec = importlib.util.find_spec(module)
             if spec is None: #module has not been imported/found correctly
-                self.show_error_dialog("Python module: "+module+" has not been imported correctly",
-                    "This python module is required for AutoKey to function properly")
-                sys.exit("Missing python modules")
-            else: 
-                # print(spec)
-                pass
+                missing_modules.append(module)
 
         #test for if command line programs used by AutoKey are installed on the system
         # visgrep comes from xautomation
@@ -111,15 +106,21 @@ class Application:
 
         gtk_programs = ['zenity']
 
+        missing_programs = []
         for program in linux_programs+programs+gtk_programs:
             if which(program) is None:
                 # file not found by shell
-                self.show_error_dialog(program+" was not found installed on your system.",
-                    "This program is needed for autokey to function properly")
-                sys.exit("Missing command line program")
-            else:
-                #file was found fine.
-                pass
+                missing_programs.append(program)
+
+        if len(missing_programs)>0 or len(missing_modules)>0:
+            error_message = ""
+            for item in missing_programs:
+                error_message+= "Program: "+item+"\n"
+            for item in missing_modules:
+                error_message+= "Python Module: "+item+"\n"
+
+            self.show_error_dialog("AutoKey Requires the following programs or python modules to be installed to function properly", error_message)
+            sys.exit("missing programs or modules:\n"+str(missing_programs)+str(missing_modules))
 
 
         args = autokey.argument_parser.parse_args()

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -303,7 +303,7 @@ class Application(QApplication):
         Convenience method for showing an error dialog.
         """
         # TODO: i18n
-        logger.info("Displaying Error Dialog")
+        logger.debug("Displaying Error Dialog")
         message_box = QMessageBox(
             QMessageBox.Critical,
             "Error",

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -106,11 +106,11 @@ class Application(QApplication):
             self.show_error_dialog("Fatal error starting AutoKey.", str(e))
             sys.exit(1)
 
+        checkOptionalPrograms()
         missing_reqs = checkRequirements()
         if len(missing_reqs)>0:
             self.show_error_dialog("AutoKey Requires the following programs or python modules to be installed to function properly\n\n"+missing_reqs)
             sys.exit("Missing required programs and/or python modules, exiting")
-        checkOptionalPrograms()
 
         logger.info("Initialising application")
         self.setWindowIcon(QIcon.fromTheme(common.ICON_FILE, ui_common.load_icon(ui_common.AutoKeyIcon.AUTOKEY)))

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -45,6 +45,7 @@ from autokey.qtui.popupmenu import PopupMenu
 from autokey.qtui.configwindow import ConfigWindow
 from autokey.qtui.dbus_service import AppService
 from autokey.logger import get_logger, configure_root_logger
+from autokey.UI_common_functions import checkRequirements, checkOptionalPrograms
 
 logger = get_logger(__name__)
 del get_logger
@@ -104,6 +105,13 @@ class Application(QApplication):
             logger.exception("Fatal error starting AutoKey: " + str(e))
             self.show_error_dialog("Fatal error starting AutoKey.", str(e))
             sys.exit(1)
+
+        missing_reqs = checkRequirements()
+        if len(missing_reqs)>0:
+            self.show_error_dialog("AutoKey Requires the following programs or python modules to be installed to function properly\n\n"+missing_reqs)
+            sys.exit("Missing required programs and/or python modules, exiting")
+        checkOptionalPrograms()
+
         logger.info("Initialising application")
         self.setWindowIcon(QIcon.fromTheme(common.ICON_FILE, ui_common.load_icon(ui_common.AutoKeyIcon.AUTOKEY)))
         try:
@@ -295,6 +303,7 @@ class Application(QApplication):
         Convenience method for showing an error dialog.
         """
         # TODO: i18n
+        logger.info("Displaying Error Dialog")
         message_box = QMessageBox(
             QMessageBox.Critical,
             "Error",


### PR DESCRIPTION
Add stuff to check that the appropriate python modules and commands are installed, checks for Xlib, dbus, pynotify and gi, along with other python modules, that in my understanding should be distributed with most versions of python, but better safe than sorry. If any packages are missing the program will quit with `sys.exit`. 

Checks if command line programs are installed as well using `which` from `shutil` module. Only checks for currently required programs to be installed as dictated for `autokey-gtk` in `debian/control`, (`zenity`, `wmctrl`, `ps`).

Error is displayed using the provided `show_error_message` which is a wrapper for `MessageDialog`. Not sure how much can be done about the layout of the information, it is a bit weird the way it is now imo, but also not sure how much effort should be applied to what should be a rare error case/scenario.

![Screenshot from 2020-12-02 19-24-26](https://user-images.githubusercontent.com/1707320/100947813-69f05000-34d4-11eb-915c-91d106dcc715.png)
