### PR TITLE
[GTK/Qt] Add error menu item.

### DIFF
--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -236,6 +236,8 @@ class Application:
         """
         message = "The script '{}' encountered an error".format(error.script_name)
         self.notifier.notify_error(message)
+        if self.configWindow is not None:
+            self.configWindow.set_has_errors(True)
 
     def update_notifier_visibility(self):
         self.notifier.update_visible_status()

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -889,6 +889,7 @@ close and reopen the AutoKey window.\nThis message is only shown once per sessio
             canMacro = False
             canPlay = False
             enableAny = False
+            hasError = False
         else:
             canCreate = isinstance(items[0], autokey.model.folder.Folder) and len(items) == 1
             canCopy = True
@@ -896,6 +897,8 @@ close and reopen the AutoKey window.\nThis message is only shown once per sessio
             canMacro = isinstance(items[0], autokey.model.phrase.Phrase) and len(items) == 1
             canPlay = isinstance(items[0], autokey.model.script.Script) and len(items) == 1
             enableAny = True
+            hasError = self.app.service.scriptRunner.error_records
+                
             for item in items:
                 if isinstance(item, autokey.model.folder.Folder):
                     canCopy = False
@@ -910,11 +913,15 @@ close and reopen the AutoKey window.\nThis message is only shown once per sessio
         self.uiManager.get_action("/MenuBar/Edit/insert-macro").set_sensitive(canMacro)
         self.uiManager.get_action("/MenuBar/Tools/record").set_sensitive(canRecord)
         self.uiManager.get_action("/MenuBar/Tools/run").set_sensitive(canPlay)
+        self.uiManager.get_action("/MenuBar/Tools/script-error").set_sensitive(hasError)
 
         if changed:
             self.uiManager.get_action("/MenuBar/File/save").set_sensitive(False)
             self.uiManager.get_action("/MenuBar/Edit/undo").set_sensitive(False)
             self.uiManager.get_action("/MenuBar/Edit/redo").set_sensitive(False)
+
+    def set_has_errors(self, state):
+        self.uiManager.get_action("/MenuBar/Tools/script-error").set_sensitive(state)
 
     def set_undo_available(self, state):
         self.uiManager.get_action("/MenuBar/Edit/undo").set_sensitive(state)

--- a/lib/autokey/gtkui/data/menus.xml
+++ b/lib/autokey/gtkui/data/menus.xml
@@ -57,6 +57,7 @@
             <toolitem action="delete-item" />
             <separator />
             <toolitem action="run" />
+            <toolitem action="script-error"/>
         </toolbar>
         <popup name="NewDropdown">
 		    <menuitem action="new-top-folder" />

--- a/lib/autokey/gtkui/dialogs.py
+++ b/lib/autokey/gtkui/dialogs.py
@@ -150,6 +150,7 @@ class ShowScriptErrorsDialog(DialogBase):
 
     def clear_all_errors(self, button):
         self.error_list.clear()
+        self.parent.set_has_errors(False)
         self.on_close(button)
 
     def delete_currently_shown_error(self, button):

--- a/lib/autokey/qtui/resources/ui/mainwindow.ui
+++ b/lib/autokey/qtui/resources/ui/mainwindow.ui
@@ -135,6 +135,7 @@
    <addaction name="action_redo"/>
    <addaction name="separator"/>
    <addaction name="action_run_script"/>
+   <addaction name="action_show_last_script_errors"/>
   </widget>
   <action name="action_new_top_folder">
    <property name="icon">


### PR DESCRIPTION
A modification of #455 on the develop branch that also includes setting the Gtk Error Icon active/inactive depending on if there are errors left in the error dialog that have not been deleted. 

Fixes #453 



![Screenshot from 2020-12-02 15-30-05](https://user-images.githubusercontent.com/1707320/100928329-0d7d3880-34b4-11eb-91d5-118db962cbc8.png)
![Screenshot from 2020-12-02 15-29-58](https://user-images.githubusercontent.com/1707320/100928331-0e15cf00-34b4-11eb-8ab5-8db231a39648.png)
![Screenshot from 2020-12-02 15-11-31](https://user-images.githubusercontent.com/1707320/100928332-0e15cf00-34b4-11eb-941b-27c36a34abd8.png)
![Screenshot from 2020-12-02 15-11-19](https://user-images.githubusercontent.com/1707320/100928334-0e15cf00-34b4-11eb-9b66-9da5574a14df.png)