### PR TITLE
Fix for issue #483, original by fx-kirin

### DIFF
--- a/lib/autokey/scripting/system.py
+++ b/lib/autokey/scripting/system.py
@@ -43,10 +43,8 @@ class System:
                     stdout=subprocess.PIPE,
                     universal_newlines=True) as p:
                 output = p.communicate()[0]
-                if len(output) > 0:
-                    # Most shell output has a new line at the end, which we
-                    # don't want. Strip trailing newline.
-                    output = output.rstrip('\n')
+                # Most shell output has a new line at the end, which we don't want.
+                output = output.rstrip("\n")
                 if p.returncode:
                     raise subprocess.CalledProcessError(p.returncode, output)
                 return output

--- a/lib/autokey/scripting/system.py
+++ b/lib/autokey/scripting/system.py
@@ -43,11 +43,10 @@ class System:
                     stdout=subprocess.PIPE,
                     universal_newlines=True) as p:
                 output = p.communicate()[0]
-                if output.endswith("\n"):
+                if len(output) > 0:
                     # Most shell output has a new line at the end, which we
-                    # don't want. Drop the trailing newline character,
-                    # if the command output something that ends on "\n"
-                    output = output[:-1]
+                    # don't want. Strip trailing newline.
+                    output = output.rstrip('\n')
                 if p.returncode:
                     raise subprocess.CalledProcessError(p.returncode, output)
                 return output


### PR DESCRIPTION
Also swaps from striping trailing new line using indexes to `rstrip('\n')`.

See https://github.com/autokey/autokey/pull/486/files#r532656403.

Output of `subprocess` seems to always be at least a empty string: `''`, so checking length shouldn't be a problem, no more than the previous method, `endswith` which also (I think) assumes output to be a string.

Credit goes to https://github.com/fx-kirin for original fix.