### PR TITLE
Add `send_notification` to GTK and Qt `dialog` modules, uses `zenity`…

### DIFF
--- a/lib/autokey/scripting/dialog_gtk.py
+++ b/lib/autokey/scripting/dialog_gtk.py
@@ -46,6 +46,19 @@ class GtkDialog:
 
         return DialogData(return_code, output)
 
+    def send_notification(self, title, message, icon="autokey", **kwargs):
+        """
+        Sends a notification using C{zenity}
+
+        @param title: Title to be used in the notification
+        @param message: Message displayed in the notification
+        @param icon: Icon for zenity to use. Defaults to Autokey icon
+        @return: A tuple containing the exit code and user input
+        @rtype: C{tuple(int, str)}
+
+        """
+        return self._run_zenity("Autokey Notification", ["--notification", "--text", title+"\n"+message, "--window-icon", icon], kwargs)
+
     def info_dialog(self, title="Information", message="", **kwargs):
         """
         Show an information dialog

--- a/lib/autokey/scripting/dialog_qt.py
+++ b/lib/autokey/scripting/dialog_qt.py
@@ -46,6 +46,19 @@ class QtDialog:
 
         return DialogData(return_code, output)
 
+    def send_notification(self, title, message, icon="autokey", timeout="10", **kwargs):
+        """
+        Sends a passive popup (notification) using C{kdialog}
+
+        @param title: Title to be used in the notification
+        @param message: Message to be displayed in the notification
+        @param icon: Icon to be used in the notification (Defaults to "autokey")
+        @param timeout: How long the notification will be on screen (Defaults to 10)
+        @return: A tuple containing the exit code and user input
+        @rtype: C{DialogData(int, str)}
+        """
+        return self._run_kdialog(title, ["--title", title, "--passivepopup", message, "--icon", icon, str(timeout)], kwargs)
+
     def info_dialog(self, title="Information", message="", **kwargs):
         """
         Show an information dialog


### PR DESCRIPTION
… and `kdialog` respectively.

`kdialog` has the option to add a timeout explicitly to the notification (referred to as passive popups in the documentation), but on my Gtk based machine it sends the notification the same way as `zenity`, I assume that if you are using a Qt desktop manager the timeout will function as expected.

For the Gtk based notification the easiest way to make it have both a "title" and a "message" was to separate them with a newline, I assume that this is what is happening at some level on the other ways of sending notification (looks the same as ones sent via `notify-send` or `kdialog`)

Other than that I think it is pretty straight forward what's happening in this commit.

References can be found below;
https://unix.stackexchange.com/questions/516618/what-are-the-differences-disadvantages-of-zenity-vs-notify-send
https://develop.kde.org/deploy/kdialog/#non-interrupting-notifications
https://help.gnome.org/users/zenity/stable/notification.html.en