### PR TITLE
Develop slowtypemethod

### DIFF
--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -789,7 +789,7 @@ class XInterfaceBase(threading.Thread):
                     logger.warning("Unable to send character %r", char)
                 logger.info("Type delay of "+str(type_delay))
                 if type_delay >= 0:
-                    self.localDisplay.flush()
+                    self.flush()
                     time.sleep(type_delay)
             except Exception as e:
                 logger.exception("Error sending char %r: %s", char, str(e))

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -692,10 +692,10 @@ class XInterfaceBase(threading.Thread):
 
         return None, None
 
-    def send_string(self, string):
-        self.__enqueue(self.__sendString, string)
+    def send_string(self, string, type_delay=0):
+        self.__enqueue(self.__sendString, string, type_delay)
         
-    def __sendString(self, string):
+    def __sendString(self, string, type_delay=0):
         """
         Send a string of printable characters.
         """
@@ -787,6 +787,10 @@ class XInterfaceBase(threading.Thread):
                         self.__releaseKey(Key.SHIFT)
                 else:
                     logger.warning("Unable to send character %r", char)
+                logger.info("Type delay of "+str(type_delay))
+                if type_delay >= 0:
+                    self.localDisplay.flush()
+                    time.sleep(type_delay)
             except Exception as e:
                 logger.exception("Error sending char %r: %s", char, str(e))
 

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -142,7 +142,7 @@ class IoMediator(threading.Thread):
         
     # Methods for expansion service ----
 
-    def send_string(self, string: str):
+    def send_string(self, string: str, type_delay=0):
         """
         Sends the given string for output.
         """
@@ -170,14 +170,14 @@ class IoMediator(threading.Thread):
                         else:
                             self.interface.send_modified_key(section[0], modifiers)
                             if len(section) > 1:
-                                self.interface.send_string(section[1:])
+                                self.interface.send_string(section[1:], type_delay)
                             modifiers = []
                     else:
                         # Normal string/key operation
                         if Key.is_key(section):
                             self.interface.send_key(section)
                         else:
-                            self.interface.send_string(section)
+                            self.interface.send_string(section, type_delay)
                             
         self._reapply_modifiers()
         
@@ -242,6 +242,7 @@ class IoMediator(threading.Thread):
         """
         for i in range(count):
             self.interface.send_key(Key.BACKSPACE)
+            self.flush()
 
     def flush(self):
         self.interface.flush()

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -15,6 +15,7 @@
 
 import threading
 import queue
+import time
 
 from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
@@ -236,13 +237,15 @@ class IoMediator(threading.Thread):
         for i in range(count):
             self.interface.send_key(Key.UP)
 
-    def send_backspace(self, count):
+    def send_backspace(self, count, type_delay=0):
         """
         Sends the given number of backspace key presses.
         """
         for i in range(count):
             self.interface.send_key(Key.BACKSPACE)
-            self.flush()
+            if type_delay >= 0:
+                time.sleep(type_delay)
+                self.flush()
 
     def flush(self):
         self.interface.flush()

--- a/lib/autokey/model/phrase.py
+++ b/lib/autokey/model/phrase.py
@@ -49,6 +49,7 @@ class Phrase(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
         self.show_in_tray_menu = False
         self.sendMode = SendMode.CB_CTRL_V
         self.path = path
+        self.type_delay = 0
 
     def build_path(self, base_name=None):
         if base_name is None:
@@ -84,7 +85,8 @@ class Phrase(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
             "abbreviation": AbstractAbbreviation.get_serializable(self),
             "hotkey": AbstractHotkey.get_serializable(self),
             "filter": AbstractWindowFilter.get_serializable(self),
-            "sendMode": self.sendMode.value
+            "sendMode": self.sendMode.value,
+            "type_delay": self.type_delay
             }
         return d
 
@@ -117,6 +119,11 @@ class Phrase(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
         self.matchCase = data["matchCase"]
         self.show_in_tray_menu = data["showInTrayMenu"]
         self.sendMode = SendMode(data.get("sendMode", SendMode.KEYBOARD))
+        try:
+            self.type_delay = data["type_delay"]
+        except:
+            logger.error("Type delay not found")
+
         AbstractAbbreviation.load_from_serialized(self, data["abbreviation"])
         AbstractHotkey.load_from_serialized(self, data["hotkey"])
         AbstractWindowFilter.load_from_serialized(self, data["filter"])

--- a/lib/autokey/model/phrase.py
+++ b/lib/autokey/model/phrase.py
@@ -86,7 +86,7 @@ class Phrase(AbstractAbbreviation, AbstractHotkey, AbstractWindowFilter):
             "hotkey": AbstractHotkey.get_serializable(self),
             "filter": AbstractWindowFilter.get_serializable(self),
             "sendMode": self.sendMode.value,
-            "type_delay": self.type_delay
+            "type_delay": self.type_delay,
             }
         return d
 

--- a/lib/autokey/scripting/engine.py
+++ b/lib/autokey/scripting/engine.py
@@ -143,7 +143,8 @@ Folders created within temporary folders must themselves be set temporary")
                       hotkey: Tuple[List[Union[Key, str]], Union[Key, str]]=None,
                       send_mode: autokey.model.phrase.SendMode = autokey.model.phrase.SendMode.CB_CTRL_V, window_filter: str=None,
                       show_in_system_tray: bool=False, always_prompt: bool=False,
-                      temporary=False, replace_existing_hotkey=False):
+                      temporary=False, replace_existing_hotkey=False,
+                      type_delay=0):
         """
         Create a new text phrase inside the given folder. Use C{engine.get_folder(folder_name)} to retrieve the folder
         you wish to create the Phrase in. If the folder is a temporary
@@ -217,6 +218,7 @@ Folders created within temporary folders must themselves be set temporary")
         @param replace_existing_hotkey: If true, instead of warning if the hotkey
             is already in use by another phrase or folder, it removes the hotkey
             from those clashes and keeps this phrase's hotkey.
+        @param type_delay: 
         @raise ValueError: If a given abbreviation or hotkey is already in use or parameters are otherwise invalid
         @return The created Phrase object. This object is NOT considered part of the public API and exposes the raw
           internals of AutoKey. Ignore it, if you don’t need it or don’t know what to do with it.
@@ -262,6 +264,8 @@ Folders created within temporary folders must themselves be set temporary")
             # reloads.
             if not temporary:
                 p.persist()
+
+            p.type_delay = type_delay
             return p
         finally:
             self.monitor.unsuspend()

--- a/lib/autokey/scripting/keyboard.py
+++ b/lib/autokey/scripting/keyboard.py
@@ -32,6 +32,21 @@ class Keyboard:
         self.mediator = mediator  # type: iomediator.IoMediator
         """See C{IoMediator} documentation"""
 
+    def slow_type(self, key_string, type_delay):
+        """
+        Sends a sequence of keys via keyboard events with a delay between each key.
+
+        @param key_string: string of keys to send.
+        @param type_delay: Delay between each key event being sent (uses python's time.sleep)
+        """
+        if not isinstance(key_string, str):
+            raise TypeError("Only strings can be sent using this function")
+        self.mediator.interface.begin_send()
+        try:
+            self.mediator.send_string(key_string, type_delay)
+        finally:
+            self.mediator.interface.finish_send()
+
     def send_keys(self, key_string, send_mode: typing.Union[
         autokey.model.phrase.SendMode, int] = autokey.model.phrase.SendMode.KEYBOARD):
         """
@@ -45,7 +60,7 @@ class Keyboard:
 
         Usage: C{keyboard.send_keys(keyString)}
 
-        @param key_string: string of keys to send. Special keys are only possible in keyboard mode.
+        @param key_string: 
         @param send_mode: Determines how the string is sent.
         """
 

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -413,7 +413,7 @@ class PhraseRunner:
             self.contains_special_keys = self.phrase_contains_special_keys(expansion)
             mediator.send_backspace(expansion.backspaces)
             if phrase.sendMode == autokey.model.phrase.SendMode.KEYBOARD:
-                mediator.send_string(expansion.string)
+                mediator.send_string(expansion.string, phrase.type_delay)
             else:
                 mediator.paste_string(expansion.string, phrase.sendMode)
 

--- a/lib/autokey/service.py
+++ b/lib/autokey/service.py
@@ -411,7 +411,7 @@ class PhraseRunner:
                     self.macroManager.process_expansion_macros(expansion.string)
 
             self.contains_special_keys = self.phrase_contains_special_keys(expansion)
-            mediator.send_backspace(expansion.backspaces)
+            mediator.send_backspace(expansion.backspaces, phrase.type_delay)
             if phrase.sendMode == autokey.model.phrase.SendMode.KEYBOARD:
                 mediator.send_string(expansion.string, phrase.type_delay)
             else:


### PR DESCRIPTION
Adds the option to have a delay between sending keystrokes, as has been suggested as a solution to issues with trigger phrases not being completely removed. If we could get someone who has this problem to confirm that this would be a fix I'll work on adding the option to the Gtk UI.

Right now I have it set up to use the same delay for both the backspaces to remove a trigger word and the phrase itself.

If you want to test this you need to clone this branch `git clone https://github.com/sebastiansam55/autokey --branch develop-slowtypemethod`, go to the `lib` directory in the terminal and launch via `python3 -m autokey.gtkui -lc` (Qt should reflect these changes as well). Then open the json file of the phrase that you want to type with a delay and add `"type_delay": 0.1` to the end, making sure that the json is properly formatted.

My config file is pictured below
![Screenshot from 2021-08-24 07-28-04](https://user-images.githubusercontent.com/1707320/130608769-118ac256-31a4-4d18-a12e-7ef689ee1c51.png)

The change uses python's `time.sleep()` method and is only activated when `type_delay` is greater than or equal to 0.

If someone can confirm this fix I can;
* add this to the UI
* add it for abbreviation triggers for scripts
* Add a `keyboard` module method