### PR TITLE
Fix (GTK): Use correct theme in phrasepage

### DIFF
--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -649,7 +649,7 @@ class PhrasePage(ScriptPage):
         #self.__m = GtkSource.LanguageManager()
         self.__sm = GtkSource.StyleSchemeManager()
         self.buffer.set_language(None)
-        self.buffer.set_style_scheme(self.__sm.get_scheme("kate"))
+        self.buffer.set_style_scheme(self.__sm.get_scheme(cm.ConfigManager.SETTINGS[cm_constants.GTK_THEME]))
         self.buffer.set_highlight_matching_brackets(False)
         self.editor.set_auto_indent(False)
         self.editor.set_smart_home_end(False)


### PR DESCRIPTION
Change PhrasePage GtkSource Buffer to use same theme as ScriptPage, pulled from config file. See #452