### PR TITLE
Use xdo to send strings instead of xrecord (allows sending unicode)

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -48,6 +48,11 @@ The old tests are scheduled to be replaced by a new suite in the `develop` branc
 
 The current situation is a bit unfortunate: The new suite lives in the develop branch, which accumulates new features, but which can't be backported to master without introducing merge conflicts later on. So until develop gets merged in, you’d have to switch to develop to run the tests.
 
+Debugging
+=========
+
+Debugging the various UIs can be done like `python -m pdb -m autokey.qtui`
+
 Program Structure
 =================
 

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -16,3 +16,4 @@ python-gobject
 zenity
 kdialog
 pyqt5-dev-tools
+xdotool

--- a/lib/autokey/abstract_ui.py
+++ b/lib/autokey/abstract_ui.py
@@ -28,3 +28,7 @@ class AutokeyUIInterface(ABC):
     @abstractmethod
     def shutdown(self):
         pass
+
+    @abstractmethod
+    def show_popup_menu(self):
+        pass

--- a/lib/autokey/headless_app.py
+++ b/lib/autokey/headless_app.py
@@ -104,6 +104,9 @@ class Application(AutokeyApplication, AutokeyUIInterface):
             """.format(message)
         )
 
+    def show_popup_menu(self):
+        pass
+
 
 import faulthandler
 faulthandler.enable()

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -29,7 +29,7 @@ import select
 import queue
 import subprocess
 import time
-import traceback
+import xdo
 
 import autokey.model.phrase
 if typing.TYPE_CHECKING:
@@ -37,7 +37,6 @@ if typing.TYPE_CHECKING:
 import autokey.configmanager.configmanager_constants as cm_constants
 from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, AbstractWindowInterface, AbstractSysKeyOutputInterface
 from autokey.sys_interface.clipboard import Clipboard
-from autokey.sys_interface.xdo_interface import XdoSendInterface
 
 
 # Imported to enable threading in Xlib. See module description. Not an unused import statement.
@@ -125,7 +124,7 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
         self.lastChars = [] # QT4 Workaround
         self.__enableQT4Workaround = False # QT4 Workaround
         self.shutdown = False
-        self.xdo = XdoSendInterface(app, mediator)
+        self.doer = xdo.Xdo()
 
         # Event loop
         self.eventThread = threading.Thread(target=self.__eventLoop)
@@ -343,6 +342,18 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
                 logger.exception("Error in X event loop thread: {}".format(e))
 
             self.queue.task_done()
+
+    def xdowrite_delayed(self, text: str, delay: int=12*1000, start_delay:float=1):
+        """
+        Types text, using inter-key delay delay in μs,
+        Wait start_delay seconds before typing to allow switching
+        between windows after hitting enter in the interactive prompt.
+        """
+        time.sleep(start_delay)
+        print(f"Send {text}")
+        current_window = self.doer.get_focused_window_sane()
+        print(f"Current window={current_window}")
+        self.doer.enter_text_window(current_window, text.encode("utf-8"), delay=delay)
 
     def __enqueue(self, method: typing.Callable, *args):
         self.queue.put_nowait((method, args))
@@ -710,12 +721,6 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
         Send a string of printable characters.
         """
         logger.debug("Sending string: %r", string)
-        try:
-            self.xdo.send_string(string)
-            return
-        except Exception as e:
-            logger.error("Error sending string via xdo: {}".format(e))
-            traceback.print_exc()
         # Determine if workaround is needed
         if not cm.ConfigManager.SETTINGS[cm_constants.ENABLE_QT4_WORKAROUND]:
             self.__checkWorkaroundNeeded()
@@ -796,13 +801,7 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
 
     def __sendKey(self, keyName):
         logger.debug("Send special key: [%r]", keyName)
-        logger.debug("Send special key: [{}]".format(keyName))
-        try:
-            self.xdo.send_key(keyName)
-            return
-        except Exception as e:
-            logger.error("Error sending key via xdo: {}".format(e))
-            traceback.print_exc()
+        self.__sendKeyCode(self.__lookupKeyCode(keyName))
 
     def __fakeKeypress(self, keyName):
         keyCode = self.__lookupKeyCode(keyName)
@@ -819,12 +818,6 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
 
     def __sendModifiedKey(self, keyName, modifiers):
         logger.debug("Send modified key: modifiers: %s key: %s", modifiers, keyName)
-        try:
-            self.xdo.send_modified_key(keyName)
-            return
-        except Exception as e:
-            logger.error("Error sending modified key via xdo: {}".format(e))
-            traceback.print_exc()
         try:
             keyCode = self.__lookupKeyCode(keyName)
             self.__send_keycode_with_modifiers_pressed(keyCode,

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -29,12 +29,14 @@ import select
 import queue
 import subprocess
 import time
+import xdo
 
 import autokey.model.phrase
 if typing.TYPE_CHECKING:
     from autokey.iomediator.iomediator import IoMediator
 import autokey.configmanager.configmanager_constants as cm_constants
-from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, AbstractWindowInterface
+from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, AbstractWindowInterface, AbstractSysKeyOutputInterface
+from autokey.sys_interface.clipboard import Clipboard
 
 
 # Imported to enable threading in Xlib. See module description. Not an unused import statement.
@@ -122,6 +124,7 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
         self.lastChars = [] # QT4 Workaround
         self.__enableQT4Workaround = False # QT4 Workaround
         self.shutdown = False
+        self.doer = xdo.Xdo()
 
         # Event loop
         self.eventThread = threading.Thread(target=self.__eventLoop)
@@ -321,6 +324,18 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
                 logger.exception("Error in X event loop thread: {}".format(e))
 
             self.queue.task_done()
+
+    def xdowrite_delayed(self, text: str, delay: int=12*1000, start_delay:float=1):
+        """
+        Types text, using inter-key delay delay in μs,
+        Wait start_delay seconds before typing to allow switching
+        between windows after hitting enter in the interactive prompt.
+        """
+        time.sleep(start_delay)
+        print(f"Send {text}")
+        current_window = self.doer.get_focused_window_sane()
+        print(f"Current window={current_window}")
+        self.doer.enter_text_window(current_window, text.encode("utf-8"), delay=delay)
 
     def __enqueue(self, method: typing.Callable, *args):
         self.queue.put_nowait((method, args))
@@ -1109,7 +1124,7 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
 
 
 
-class XRecordInterface(XInterfaceBase, AbstractSysInterface):
+class XRecordInterface(XInterfaceBase, AbstractSysInterface, AbstractSysKeyOutputInterface):
 
     def initialise(self):
         self.recordDisplay = display.Display()

--- a/lib/autokey/iomediator/iomediator.py
+++ b/lib/autokey/iomediator/iomediator.py
@@ -23,6 +23,7 @@ from autokey.configmanager.configmanager import ConfigManager
 from autokey.configmanager.configmanager_constants import INTERFACE_TYPE
 from autokey.interface import XRecordInterface, AtSpiInterface
 from autokey.sys_interface.clipboard import Clipboard
+from autokey.sys_interface.xdo_interface import XdoSendInterface
 from autokey.model.phrase import SendMode
 
 from autokey.model.key import Key, KEY_SPLIT_RE, MODIFIERS, HELD_MODIFIERS
@@ -52,6 +53,7 @@ class IoMediator(threading.Thread):
         self.listeners.append(service)
         self.interfaceType = ConfigManager.SETTINGS[INTERFACE_TYPE]
         self.app = service.app
+        self.xdo = XdoSendInterface(self.app, self)
         
         # Modifier tracking
         self.modifiers = {
@@ -92,6 +94,7 @@ class IoMediator(threading.Thread):
         logger.debug("IoMediator shutdown completed")
 
     def begin_send(self):
+        # Grab keyboard to prevent user keystrokes interfering with autokey inputs.
         self.interface.grab_keyboard()
 
     def finish_send(self):
@@ -174,9 +177,9 @@ class IoMediator(threading.Thread):
         string = string.replace('\n', "<enter>")
         string = string.replace('\t', "<tab>")
         
-        logger.debug("Send via event interface")
+        logger.debug("Sending string '{}' via event interface".format(string))
         self._clear_modifiers()
-        IoMediator._send_string(string, self.interface)
+        IoMediator._send_string(string, self.xdo)
         self._reapply_modifiers()
 
     # Mainly static for the purpose of testing

--- a/lib/autokey/sys_interface/abstract_interface.py
+++ b/lib/autokey/sys_interface/abstract_interface.py
@@ -69,6 +69,9 @@ class AbstractSysInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def handle_keyrelease(self, keyCode):
         return
+    @abstractmethod
+    def send_string_clipboard(self, key_name):
+        return
 
 class AbstractSysKeyOutputInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
@@ -84,6 +87,9 @@ class AbstractSysKeyOutputInterface(ABC, metaclass=ABCMeta):
     def press_key(self, key_name):
         return
     @abstractmethod
+    def press_key(self, key_name):
+        return
+    @abstractmethod
     def release_key(self, key_name):
         return
     @abstractmethod
@@ -94,9 +100,6 @@ class AbstractSysKeyOutputInterface(ABC, metaclass=ABCMeta):
         return
     @abstractmethod
     def fake_keyup(self, key_name):
-        return
-    @abstractmethod
-    def send_string_clipboard(self, key_name):
         return
 
 

--- a/lib/autokey/sys_interface/abstract_interface.py
+++ b/lib/autokey/sys_interface/abstract_interface.py
@@ -52,7 +52,6 @@ class AbstractSysInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def handle_keyrelease(self, keyCode):
         return
-    @abstractmethod
     def grab_keyboard(self):
         return
     @abstractmethod
@@ -64,7 +63,14 @@ class AbstractSysInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def ungrab_hotkey(self, item):
         return
+    @abstractmethod
+    def handle_keypress(self, keyCode):
+        return
+    @abstractmethod
+    def handle_keyrelease(self, keyCode):
+        return
 
+class AbstractSysKeyOutputInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def send_string(self, string):
         return
@@ -77,7 +83,11 @@ class AbstractSysInterface(ABC, metaclass=ABCMeta):
     @abstractmethod
     def press_key(self, key_name):
         return
+    @abstractmethod
     def release_key(self, key_name):
+        return
+    @abstractmethod
+    def fake_keypress(self, key_name):
         return
     @abstractmethod
     def fake_keydown(self, key_name):
@@ -86,8 +96,9 @@ class AbstractSysInterface(ABC, metaclass=ABCMeta):
     def fake_keyup(self, key_name):
         return
     @abstractmethod
-    def fake_keypress(self, key_name):
+    def send_string_clipboard(self, key_name):
         return
+
 
 class AbstractMouseInterface(ABC, metaclass=ABCMeta):
     """

--- a/lib/autokey/sys_interface/xdo_interface.py
+++ b/lib/autokey/sys_interface/xdo_interface.py
@@ -34,75 +34,91 @@ from autokey.sys_interface.abstract_interface import AbstractSysInterface, Abstr
 from autokey import common
 
 
-# Imported to enable threading in Xlib. See module description. Not an unused import statement.
-import Xlib.threaded as xlib_threaded
-# Delete again, as the reference is not needed anymore after the import side-effect has done it’s work.
-# This (hopefully) also prevents automatic code cleanup software from deleting an "unused" import and re-introduce
-# issues.
-del xlib_threaded
-
-from Xlib.error import ConnectionClosedError
-
-
-if common.USED_UI_TYPE == "GTK":
-    import gi
-    gi.require_version('Gtk', '3.0')
-    try:
-        gi.require_version('Atspi', '2.0')
-        import pyatspi
-        HAS_ATSPI = True
-    except ImportError:
-        HAS_ATSPI = False
-    except ValueError:
-        HAS_ATSPI = False
-    except SyntaxError:  # pyatspi 2.26 fails when used with Python 3.7
-        HAS_ATSPI = False
-
 logger = __import__("autokey.logger").logger.get_logger(__name__)
-
-def str_or_bytes_to_bytes(x: typing.Union[str, bytes, memoryview]) -> bytes:
-    if type(x) == bytes:
-        # logger.info("using LiuLang's python3-xlib")
-        return x
-    if type(x) == str:
-        logger.debug("using official python-xlib")
-        return x.encode("utf8")
-    if type(x) == memoryview:
-        logger.debug("using official python-xlib")
-        return x.tobytes()
-    raise RuntimeError("x must be str or bytes or memoryview object, type(x)={}, repr(x)={}".format(type(x), repr(x)))
-
 
 # This tuple is used to return requested window properties.
 WindowInfo = typing.NamedTuple("WindowInfo", [("wm_title", str), ("wm_class", str)])
 
-
-class XdoSendInterface(threading.Thread, AbstractSysKeyOutputInterface):
+class XdoSendInterface(AbstractSysKeyOutputInterface):
+# class XdoSendInterface(threading.Thread, AbstractSysKeyOutputInterface):
 
     def __init__(self, mediator, app):
-        threading.Thread.__init__(self)
-        self.setDaemon(True)
-        self.setName("XdoSendInterface-thread")
+        # threading.Thread.__init__(self)
+        # self.setDaemon(True)
+        # self.setName("XdoSendInterface-thread")
         self.doer = xdo.Xdo()
         self.mediator = mediator  # type: IoMediator
         self.app = app
-        self.shutdown = False
+        # Uses XQueryKeymap
+        # self.doer.get_active_keys_to_keycode_list()
 
-        self.eventThread = threading.Thread(target=self.__eventLoop)
-        self.queue = queue.Queue()
-
-        # Event listener
-        self.listenerThread = threading.Thread(target=self.__flush_events_loop)
-        self.clipboard = Clipboard()
-
-    def write_delayed(self, text: str, delay: int=12*1000, start_delay:float=1):
+    def send_string(self, string, delay: int=5*1000):
         """
-        Types text, using inter-key delay delay in μs,
+        Types text, using inter-key delay `delay` in μs,
         Wait start_delay seconds before typing to allow switching
         between windows after hitting enter in the interactive prompt.
         """
-        time.sleep(start_delay)
-        print(f"Send {text}")
         current_window = self.doer.get_focused_window_sane()
-        print(f"Current window={current_window}")
-        self.doer.enter_text_window(current_window, text.encode("utf-8"), delay=delay)
+        self.__pause_autokey()
+        self.doer.enter_text_window(current_window, string.encode("utf-8"), delay=delay)
+
+    def send_key(self, key_name, delay: int=2*1000):
+        """
+        This allows you to send keysequences by symbol name. Any combination of
+        X11 KeySym names separated by ‘+’ are valid. Single KeySym names are
+        valid, too.
+
+        Examples:
+        “l” “semicolon” “alt+Return” “Alt_L+Tab”
+        """
+        current_window = self.doer.get_focused_window_sane()
+        self.__pause_autokey()
+        key = self.__convert_key_name_autokey_to_xdo(key_name)
+        self.doer.send_keysequence_window(current_window, key, delay=delay)
+
+    def send_modified_key(self, key_name, delay: int=2*1000):
+        self.send_key(key_name, delay)
+
+    def press_key(self, key_name, delay: int=5*1000):
+        self.__press_or_release_key(key_name, delay, press=True)
+    def release_key(self, key_name, delay: int=5*1000):
+        self.__press_or_release_key(key_name, delay, press=False)
+
+    def fake_keypress(self, key_name):
+        pass
+    def fake_keydown(self, key_name):
+        pass
+    def fake_keyup(self, key_name):
+        pass
+
+    def __press_or_release_key(self, key_name, delay: int=5*1000, press=True):
+        current_window = self.doer.get_focused_window_sane()
+        self.__pause_autokey()
+        key = self.__convert_key_name_autokey_to_xdo(key_name)
+        if press:
+            self.doer.send_keysequence_window_down(current_window, key, delay=delay)
+        else:
+            self.doer.send_keysequence_window_up(current_window, key, delay=delay)
+
+    def __convert_key_name_autokey_to_xdo(self, key_name):
+        """
+        At this stage, we rely on the assumption that all keys are sent as valid X11 KeySyms, only the modifiers are surrounded by <>
+        """
+        key_name =key_name.replace("<", "")
+        key_name =key_name.replace(">", "")
+        return key_name
+
+
+    def __pause_autokey(self):
+        """
+        Xdo works at a higher level than the rest of the xrecord interface that autokey uses.
+        This causes a couple of problems. It means that if xrecord has grabbed the keyboard to prevent input, xdo cannot input anything.
+        It also means that xdo key events are seen by autokey as user key events.
+        To avoid that, we ungrab the keyboard and pause responding to keyboard events while using xdo commands.
+        """
+        self.app.pause_service()
+        self.mediator.finish_send()
+        yield
+        self.mediator.begin_send()
+        self.app.unpause_service()
+

--- a/lib/autokey/sys_interface/xdo_interface.py
+++ b/lib/autokey/sys_interface/xdo_interface.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2021 BlueDrink9
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This file handles interactions with X, mainly sending strings.
+"""
+
+import xdo
+import time
+import typing
+import threading
+import queue
+import subprocess
+
+import autokey.model.phrase
+if typing.TYPE_CHECKING:
+    from autokey.iomediator.iomediator import IoMediator
+import autokey.configmanager.configmanager_constants as cm_constants
+from autokey.sys_interface.clipboard import Clipboard
+from autokey.sys_interface.abstract_interface import AbstractSysInterface, AbstractMouseInterface, AbstractWindowInterface, AbstractSysKeyOutputInterface
+
+from autokey import common
+
+
+# Imported to enable threading in Xlib. See module description. Not an unused import statement.
+import Xlib.threaded as xlib_threaded
+# Delete again, as the reference is not needed anymore after the import side-effect has done it’s work.
+# This (hopefully) also prevents automatic code cleanup software from deleting an "unused" import and re-introduce
+# issues.
+del xlib_threaded
+
+from Xlib.error import ConnectionClosedError
+
+
+if common.USED_UI_TYPE == "GTK":
+    import gi
+    gi.require_version('Gtk', '3.0')
+    try:
+        gi.require_version('Atspi', '2.0')
+        import pyatspi
+        HAS_ATSPI = True
+    except ImportError:
+        HAS_ATSPI = False
+    except ValueError:
+        HAS_ATSPI = False
+    except SyntaxError:  # pyatspi 2.26 fails when used with Python 3.7
+        HAS_ATSPI = False
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+def str_or_bytes_to_bytes(x: typing.Union[str, bytes, memoryview]) -> bytes:
+    if type(x) == bytes:
+        # logger.info("using LiuLang's python3-xlib")
+        return x
+    if type(x) == str:
+        logger.debug("using official python-xlib")
+        return x.encode("utf8")
+    if type(x) == memoryview:
+        logger.debug("using official python-xlib")
+        return x.tobytes()
+    raise RuntimeError("x must be str or bytes or memoryview object, type(x)={}, repr(x)={}".format(type(x), repr(x)))
+
+
+# This tuple is used to return requested window properties.
+WindowInfo = typing.NamedTuple("WindowInfo", [("wm_title", str), ("wm_class", str)])
+
+
+class XdoSendInterface(threading.Thread, AbstractSysKeyOutputInterface):
+
+    def __init__(self, mediator, app):
+        threading.Thread.__init__(self)
+        self.setDaemon(True)
+        self.setName("XdoSendInterface-thread")
+        self.doer = xdo.Xdo()
+        self.mediator = mediator  # type: IoMediator
+        self.app = app
+        self.shutdown = False
+
+        self.eventThread = threading.Thread(target=self.__eventLoop)
+        self.queue = queue.Queue()
+
+        # Event listener
+        self.listenerThread = threading.Thread(target=self.__flush_events_loop)
+        self.clipboard = Clipboard()
+
+    def write_delayed(self, text: str, delay: int=12*1000, start_delay:float=1):
+        """
+        Types text, using inter-key delay delay in μs,
+        Wait start_delay seconds before typing to allow switching
+        between windows after hitting enter in the interactive prompt.
+        """
+        time.sleep(start_delay)
+        print(f"Send {text}")
+        current_window = self.doer.get_focused_window_sane()
+        print(f"Current window={current_window}")
+        self.doer.enter_text_window(current_window, text.encode("utf-8"), delay=delay)

--- a/setup.cfg
+++ b/setup.cfg
@@ -70,8 +70,7 @@ commands =
     coverage html
 
 [testenv:lint]
-deps = coverage
-    {[testenv]deps}
+deps = {[testenv]deps}
     flake8
 commands = flake8 --count --select=E9,F63,F7,F82 --show-source --statistics --builtins=_ --max-complexity=10 --max-line-length=127 lib/autokey
 passenv = {[testenv]passenv}

--- a/setup.py
+++ b/setup.py
@@ -190,6 +190,7 @@ setup(
     install_requires=[
         'pyinotify',
         'python-xlib',
+        'python-libxdo',
         'packaging',
     ],
     extras_require={


### PR DESCRIPTION
Fixes #255, #514, #207, #424, #20, maybe others that are related to sending input.

May address issues with typing being too fast, or may exacerbate them. Who knows! But this typing system comes with a delay of its own, which may fix it for some people in the background.

Will definitely need a lot of testing, and is currently probably even more fragile than our usual system. But it works! Wow! We wondered if it could even be done!

Unsure whether it will be merged into develop proper in current form, but I'm gonna leave it alone for a while. It's burned me out a bit getting things to this state, and more fixes will require a fair bit of energy.