### PR TITLE
Potential fix for Segfault from changing files when open in AK window

### DIFF
--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -64,8 +64,9 @@ from .shared import get_ui
 
 
 def set_linkbutton(button, path, filename_only=False):
-    button.set_sensitive(True)
-
+    label = button.get_child()
+    label.set_sensitive(True)
+    
     if path.startswith(cm_constants.CONFIG_DEFAULT_FOLDER):
         text = path.replace(cm_constants.CONFIG_DEFAULT_FOLDER, _("(Default folder)"))
     else:
@@ -73,12 +74,11 @@ def set_linkbutton(button, path, filename_only=False):
 
     if filename_only:
         filename = os.path.basename(path)
-        button.set_label(filename)
+        label.set_label(filename)
     else:
-        button.set_label(text)
+        label.set_label(text)
 
     button.set_uri("file://" + path)
-    label = button.get_child()
     label.set_ellipsize(Pango.EllipsizeMode.START)
 
 

--- a/lib/autokey/model/abstract_hotkey.py
+++ b/lib/autokey/model/abstract_hotkey.py
@@ -51,7 +51,7 @@ class AbstractHotkey(AbstractWindowFilter):
             self.modes.append(TriggerMode.HOTKEY)
 
     def unset_hotkey(self):
-        self.modifiers = None
+        self.modifiers = []
         self.hotKey = None
         if TriggerMode.HOTKEY in self.modes:
             self.modes.remove(TriggerMode.HOTKEY)


### PR DESCRIPTION
Fix or at least mitigate #601. It stopped happening after I made these changes, but not convinced it's completely gone, if anyone can replicate please let me know.

Also fixes an issue with the modifiers being set to None (sets to empty list instead) which can throw a NoneType error in some scenarios.