### PR TITLE
Sync localDisplay after emitting a fake_input key event

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Create a GUI-free headless entrypoint to autokey, which can be run without GUI l
 .. ---------
 
 - Fix crash in qt macro recording window.
+- Fix fake keyboard events not being emitted in a timely manner in some cases
 
 Version 0.96.0-beta.9
 ============================

--- a/lib/autokey/interface.py
+++ b/lib/autokey/interface.py
@@ -773,15 +773,19 @@ class XInterfaceBase(threading.Thread, AbstractMouseInterface, AbstractWindowInt
     def __fakeKeypress(self, keyName):
         keyCode = self.__lookupKeyCode(keyName)
         xtest.fake_input(self.rootWindow, X.KeyPress, keyCode)
+        self.localDisplay.sync()
         xtest.fake_input(self.rootWindow, X.KeyRelease, keyCode)
+        self.localDisplay.sync()
 
     def __fakeKeydown(self, keyName):
         keyCode = self.__lookupKeyCode(keyName)
         xtest.fake_input(self.rootWindow, X.KeyPress, keyCode)
+        self.localDisplay.sync()
 
     def __fakeKeyup(self, keyName):
         keyCode = self.__lookupKeyCode(keyName)
         xtest.fake_input(self.rootWindow, X.KeyRelease, keyCode)
+        self.localDisplay.sync()
 
     def __sendModifiedKey(self, keyName, modifiers):
         logger.debug("Send modified key: modifiers: %s key: %s", modifiers, keyName)


### PR DESCRIPTION
Problem:

I was trying to script the game Elite Dangerous, and found that none of the input methods described in the documentation were suitable for writing deterministic scripts. I found that the send_key and send_keys functions were not registered in the application at all, and the press_key/release_key functions were intermittent, and behaved differently almost every time I invoked the script.

Solution:

I discovered that by inserting a sync call after the fake_input calls, that the key codes were able to be registered by the application, and the scripts became very reliable with some dead-reckoned sleeps. The scripts that I have written and are now usable thanks to this patch are here: https://github.com/gharris1727/elite-scripts/tree/main/autokey-scripts .

I do not have insight into the deeper implications of this change (performance or otherwise), and have not manually tested it's behavior with any other applications at this time.

Thanks for maintaining this software, i'm glad to be able to make use of it!