### PR TITLE
workflow python-test.yml updated to work with ubuntu-latest

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -4,31 +4,34 @@
 name: Python test
 
 on:
+  # workflow_dispatch:
   push:
+    # paths:
+    #  - "**.py"
     # Test on tags to ensure that the version metadata has been updated in tag as well.
     tags:
       - "*"
-    branches: [CI, master, develop, beta]
+    branches: [master, develop, beta]
   pull_request:
     branches: [master, develop, beta]
 
 jobs:
   Lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: [3.6, 3.10.1]
+        python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -37,6 +40,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           sudo apt update
@@ -46,7 +50,7 @@ jobs:
           pip install -r pip-requirements.txt
 
       - name: Python Code Quality and Lint
-        uses: ricardochaves/python-lint@v1.3.0
+        uses: ricardochaves/python-lint@v1.4.0
         with:
           python-root-list: "lib/autokey tests"
           use-pylint: false
@@ -75,23 +79,23 @@ jobs:
           extra-isort-options: ""
 
   pytest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: [3.6, 3.10.1]
+        python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -100,6 +104,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
+
       - name: Install dependencies
         run: |
           sudo apt update
@@ -109,11 +114,10 @@ jobs:
           pip install -r pip-requirements.txt
 
       - name: Test with tox and pytest
-        run: |
-          tox -e clean,coverage,report
+        run: tox -e clean,coverage,report
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
@@ -121,11 +125,10 @@ jobs:
         if: ${{ always() }}
 
       - name: Archive test coverage report
-        run: |
-          tar -cvzf test_coverage_report-${{ matrix.python-version }}.tar.gz test_coverage_report_html/
+        run: tar -cvzf test_coverage_report-${{ matrix.python-version }}.tar.gz test_coverage_report_html/
 
       - name: Upload test coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: test_coverage_report-${{ matrix.python-version }}.tar.gz
           path: test_coverage_report-${{ matrix.python-version }}.tar.gz
@@ -135,18 +138,18 @@ jobs:
   test-install:
     # Just runs basic app options to ensure pip installation has included relevant imports and put app in path.
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        python-version: [3.6, 3.10.1]
+        python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "${{ matrix.python-version }}"
 
       - name: Install OS dependencies only
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -7,14 +7,13 @@ on:
   push:
     # Test on tags to ensure that the version metadata has been updated in tag as well.
     tags:
-      - '*'
-    branches: [ CI, master, develop, beta ]
+      - "*"
+    branches: [CI, master, develop, beta]
   pull_request:
-    branches: [ master, develop, beta ]
+    branches: [master, develop, beta]
 
 jobs:
   Lint:
-
     runs-on: ubuntu-20.04
 
     strategy:
@@ -22,61 +21,60 @@ jobs:
         python-version: [3.6, 3.10.1]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('pip-requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install $(cat apt-requirements.txt)
-        python -m pip install --upgrade pip
-        pip install flake8 wheel
-        pip install -r pip-requirements.txt
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('pip-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install $(cat apt-requirements.txt)
+          python -m pip install --upgrade pip
+          pip install flake8 wheel
+          pip install -r pip-requirements.txt
 
-    - name: Python Code Quality and Lint
-      uses: ricardochaves/python-lint@v1.3.0
-      with:
-        python-root-list: "lib/autokey tests"
-        use-pylint: false
-        use-pycodestyle: false
-        use-flake8: true
-        use-black: false
-        use-mypy: false
-        use-isort: false
-        extra-pylint-options: ""
-        extra-pycodestyle-options: ""
-        # select = stop the build if there are Python syntax errors or undefined names
-        # exit-zero treats all errors as warnings.
-        # "_" is part of gettext, not actually a built-in, but used almost
-        # everywhere without explicit definition.
-        # The GitHub editor is 127 chars wide.
-        extra-flake8-options: >
-          --count
-          --select=E9,F63,F7,F82
-          --show-source
-          --statistics
-          --builtins=_
-          --max-complexity=10
-          --max-line-length=127
-        extra-black-options: ""
-        extra-mypy-options: ""
-        extra-isort-options: ""
+      - name: Python Code Quality and Lint
+        uses: ricardochaves/python-lint@v1.3.0
+        with:
+          python-root-list: "lib/autokey tests"
+          use-pylint: false
+          use-pycodestyle: false
+          use-flake8: true
+          use-black: false
+          use-mypy: false
+          use-isort: false
+          extra-pylint-options: ""
+          extra-pycodestyle-options: ""
+          # select = stop the build if there are Python syntax errors or undefined names
+          # exit-zero treats all errors as warnings.
+          # "_" is part of gettext, not actually a built-in, but used almost
+          # everywhere without explicit definition.
+          # The GitHub editor is 127 chars wide.
+          extra-flake8-options: >
+            --count
+            --select=E9,F63,F7,F82
+            --show-source
+            --statistics
+            --builtins=_
+            --max-complexity=10
+            --max-line-length=127
+          extra-black-options: ""
+          extra-mypy-options: ""
+          extra-isort-options: ""
 
   pytest:
-
     runs-on: ubuntu-20.04
 
     strategy:
@@ -84,55 +82,55 @@ jobs:
         python-version: [3.6, 3.10.1]
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('pip-requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
-    - name: Install dependencies
-      run: |
-        sudo apt update
-        sudo apt install $(cat apt-requirements.txt)
-        python -m pip install --upgrade pip
-        pip install flake8 tox pytest pytest-cov wheel
-        pip install -r pip-requirements.txt
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('pip-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install $(cat apt-requirements.txt)
+          python -m pip install --upgrade pip
+          pip install flake8 tox pytest pytest-cov wheel
+          pip install -r pip-requirements.txt
 
-    - name: Test with tox and pytest
-      run: |
-        tox -e clean,coverage,report
+      - name: Test with tox and pytest
+        run: |
+          tox -e clean,coverage,report
 
-    - name: Upload pytest test results
-      uses: actions/upload-artifact@v2
-      with:
-        name: pytest-results-${{ matrix.python-version }}
-        path: junit/test-results-${{ matrix.python-version }}.xml
-      # Use always() to always run this step to publish test results when there are test failures
-      if: ${{ always() }}
+      - name: Upload pytest test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: pytest-results-${{ matrix.python-version }}
+          path: junit/test-results-${{ matrix.python-version }}.xml
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
 
-    - name: Archive test coverage report
-      run: |
-        tar -cvzf test_coverage_report-${{ matrix.python-version }}.tar.gz test_coverage_report_html/
+      - name: Archive test coverage report
+        run: |
+          tar -cvzf test_coverage_report-${{ matrix.python-version }}.tar.gz test_coverage_report_html/
 
-    - name: Upload test coverage report
-      uses: actions/upload-artifact@v2
-      with:
-        name: test_coverage_report-${{ matrix.python-version }}.tar.gz
-        path: test_coverage_report-${{ matrix.python-version }}.tar.gz
-      # Use always() to always run this step to publish test results when there are test failures
-      if: ${{ always() }}
+      - name: Upload test coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: test_coverage_report-${{ matrix.python-version }}.tar.gz
+          path: test_coverage_report-${{ matrix.python-version }}.tar.gz
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}
 
   test-install:
     # Just runs basic app options to ensure pip installation has included relevant imports and put app in path.
@@ -144,23 +142,23 @@ jobs:
         python-version: [3.6, 3.10.1]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Install OS dependencies only
-      run: |
-        sudo apt update
-        sudo apt install $(cat apt-requirements.txt)
-        python -m pip install --upgrade pip
-        pip install dbus-python gobject pygobject PyQt5 qscintilla
+      - name: Install OS dependencies only
+        run: |
+          sudo apt update
+          sudo apt install $(cat apt-requirements.txt)
+          python -m pip install --upgrade pip
+          pip install dbus-python gobject pygobject PyQt5 qscintilla
 
-    - name: Test installation
-      run: |
-        pip install "${GITHUB_WORKSPACE}"
-        autokey-gtk --help
-        # qt xcb module requires a display to connect to, so won't work.
-        # export QT_DEBUG_PLUGINS=1
-        # autokey-qt --help
+      - name: Test installation
+        run: |
+          pip install "${GITHUB_WORKSPACE}"
+          autokey-gtk --help
+          # qt xcb module requires a display to connect to, so won't work.
+          # export QT_DEBUG_PLUGINS=1
+          # autokey-qt --help

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -1,4 +1,5 @@
 dbus
+python3-dbus
 libdbus-1-dev
 libpython3-dev
 libdbus-glib-1-dev

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -1,6 +1,4 @@
 dbus
-python3-dbus
-python-dbus
 libdbus-1-dev
 libpython3-dev
 libdbus-glib-1-dev
@@ -12,7 +10,6 @@ gir1.2-appindicator3-0.1
 gir1.2-glib-2.0
 gir1.2-notify-0.7
 python3-gi
-python-gobject
 zenity
 kdialog
 pyqt5-dev-tools


### PR DESCRIPTION
- All actions updated to current version major
- commented - trigger workflow manually
- commented - Only run on py extension push
- yaml and workflow formatting
- Python version 3.6 change to 3.7 this is the oldest supported version for 22.04, see - https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
- not squashed so you can see the changes better in the stages they were applied.