### PR TITLE
Add the x11-xserver-utils pkg to get xhost.

### DIFF
--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -14,3 +14,4 @@ python3-gi
 zenity
 kdialog
 pyqt5-dev-tools
+x11-xserver-utils


### PR DESCRIPTION
This should fix the **xhost** errors we're seeing in the **develop** PR.