### PR TITLE
Change apt to apt-get.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,8 +38,8 @@ jobs:
           ${{ runner.os }}-
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install $(cat apt-requirements.txt)
+        sudo apt-get update
+        sudo apt-get install $(cat apt-requirements.txt)
         python -m pip install --upgrade pip
         pip install flake8 pytest pytest-cov wheel
         pip install -r pip-requirements.txt
@@ -85,8 +85,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt update
-        sudo apt install $(cat apt-requirements.txt)
+        sudo apt-get update
+        sudo apt-get install $(cat apt-requirements.txt)
         python -m pip install --upgrade pip
         pip install build
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -43,8 +43,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install $(cat apt-requirements.txt)
+          sudo apt-get update
+          sudo apt-get install $(cat apt-requirements.txt)
           python -m pip install --upgrade pip
           pip install flake8 wheel
           pip install -r pip-requirements.txt
@@ -107,8 +107,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install $(cat apt-requirements.txt)
+          sudo apt-get update
+          sudo apt-get install $(cat apt-requirements.txt)
           python -m pip install --upgrade pip
           pip install flake8 tox pytest pytest-cov wheel
           pip install -r pip-requirements.txt
@@ -153,8 +153,8 @@ jobs:
 
       - name: Install OS dependencies only
         run: |
-          sudo apt update
-          sudo apt install $(cat apt-requirements.txt)
+          sudo apt-get update
+          sudo apt-get install $(cat apt-requirements.txt)
           python -m pip install --upgrade pip
           pip install dbus-python gobject pygobject PyQt5 qscintilla
       - name: Test installation

--- a/INSTALL
+++ b/INSTALL
@@ -15,4 +15,4 @@ Or the Qt version:
 sudo dpkg --install autokey-qt_<version>.deb autokey-common_<version>.deb
 
 After dpkg finished, run this to install any missing dependencies:
-sudo apt install -f
+sudo apt-get install -f

--- a/debian/build.sh
+++ b/debian/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 [ -f debian/build_requirements.txt ] && \
-  cat debian/build_requirements.txt | xargs sudo apt install -y
+  cat debian/build_requirements.txt | xargs sudo apt-get install -y
 
 VERSION=$(git describe --tags --abbrev=0 --match "v*.*.*")
 # Strip leading 'v' because that is invalid as a debian version number


### PR DESCRIPTION
This satisfies changes in **develop**, which is one of the three branches described as needing it in issue #772.
