### PR TITLE
Update extractDoc.py, gtk autocomplete

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,10 +15,13 @@ Important misc changes
 - Update action versions in build.yaml to latest.
 - Update Qt/GTK "Run" button in interface to run on F5
 - Update two links in the **README.rst** file.
+- Updated `extractDoc.py`
+- Updated Qt autocomplete api.txt file (last updated in 2019)
 
 Features
 ---------
 Create a GUI-free headless entrypoint to autokey, which can be run without GUI libraries and controlled purely via scripting API
+Added Gtk autocomplete for both scripts and phrases
 
 Bug fixes
 ---------

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -23,6 +23,8 @@ GitHub Actions are used to run tests on pull requests to `master` and
 Tagged releases merged into `develop`, `beta` and `master` will
 automatically be built.
 
+If you make any scripting API changes please be sure to run `python3 extractDoc.py` to regenerate the autocompletion text files used by both Qt and GTK. (and add the changes to your commit!)
+
 Testing
 =======
 Running the tests is simple: Checkout `develop` (or v>0.96.0) and run `tox`
@@ -70,3 +72,36 @@ https://github.com/autokey/autokey/issues/255 contains a good explanation of how
 Creating and modifying phrases and hotkeys is done through the ConfigManager.
 
 For a detailed walkthrough of how phrases work, see [this comment](https://github.com/autokey/autokey/issues/334#issuecomment-564203873)
+
+
+Autocomplete in the text Editors
+--------------------------------
+Ironically, Qt API autocomplete is super easy to implement but macro/phrase autocomplete appears to be relatively complex.
+
+Gtk Autocomplete is a bit different but I think I've handled it in a pretty good way here.
+
+Both autocomplete implementations are designed to use the output of the extractDoc.py script, this uses the `ast` python module to read in and parse the scripting api and the currently available macros.
+Developers should be aware of exactly where all that information gets pulled from;
+- args come straight from `ast`` and removes `self` if it's present. 
+- It pulls the "comment" from the first line of the DocString, so this should be a short and concise description of the method.
+
+For Macros (currently GTK Autocomplete only):
+- uses the ID, TITLE and ARGS values to generate the lines
+- the was the translation function is used needs to be consistent because it changes the AST, just make any new macros look like the old ones. 
+
+
+For the GTK autocomplete it's sort of custom handling to read in the information for autocompletion, it requires an entire class, Qt interface uses QScintilla text editor which makes it pretty easy.
+
+
+Qt Autocomplete
+^^^^^^^^^^^^^^^
+API Autocomplete happens by using the `QSci.QsciAPIs`, this just reads in the content of the api.txt file.
+
+At this time it doesn't seem like there is a super easy way to add autocomplete to the phrase page, it appears to use a QTextEdit widget, and from what I've read/seen online there is not a super easy way to add autocomplete to that. PRs welcome!
+
+
+GTK Autocomplete
+^^^^^^^^^^^^^^^^
+API Autocomplete reads in the content of the `lib/autokey/gtkui/data/api.csv`, where column 0 is the API call and column 1 is the description. 
+
+Uses the same class for Macro autocomplete, makes the logic a bit tricky, may be worth separating them to be simpler to read. PRs welcome.

--- a/extractDoc.py
+++ b/extractDoc.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright (C) 2008 Chris Dekter
+# Copyright (C) 2023 Sam Sebastian
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,28 +16,199 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
-import sys, inspect
-sys.path.append("./src/lib")
-import scripting
+import ast
+import csv
+import pathlib
 
+def get_api(filepath, module_name=None, csv=False):
+    """
+    Reads in a python file, parses with `ast`, builds a list of the functions available in the file.
 
-if __name__ == "__main__":
+    Ignores functions that start with a "_" these are typically considered internal and should only be used by those who know of them.
+
     
-    outFile = open("src/lib/qtui/data/api.txt", "w")
-    
-    for name, attrib in inspect.getmembers(scripting):
-        
-        if inspect.isclass(attrib) and not (name.startswith("_") or name.startswith("Gtk")):
-            for name, attrib in inspect.getmembers(attrib):
-                if inspect.ismethod(attrib) and not name.startswith("_"):
-                    doc = attrib.__doc__
-                    lines = doc.split('\n')
-                    try:
-                        apiLine = lines[3].strip()
-                        docLine = lines[1].strip()
-                    except:
-                        continue
-                    
-                    outFile.write(apiLine[9:-1] + " " + docLine +  '\n')
+    :param filepath: Filepath to load python script from
+    :param module_name: Over write the module name, used for highlevel, qt/gtk specific things
+    :param csv: changes output to csv, for use with Gtk autocompletion file
+    """
+    api = []
+    with open(filepath, 'r') as f:
+        module_ast = ast.parse(f.read())
+
+    for node in module_ast.body:
+        if isinstance(node, ast.FunctionDef): # mostly highlevel where there is not a class
+            #print(node.name)
+
+            args = [arg.arg for arg in node.args.args if arg.arg != "self"]
             
-    outFile.close()
+
+            # grab only the first line of the doc string
+            if node.name[0] == "_": #skip internal methods
+                continue
+
+            comment = ast.get_docstring(node)
+            if comment:
+                comment = comment.split('\n')[0]
+
+            line = ""
+            module_name_output = module_name
+            if module_name is None:
+                module_name_output = pathlib.Path(filepath).stem # for engine functions outside of the class, returns "engine"
+                
+
+            if csv:
+                line = [f"{module_name_output}.{node.name}({', '.join(args)})", comment]
+            else:
+                line = f"{module_name_output}.{node.name}({', '.join(args)}) {comment}"
+
+            api.append(line)
+
+        elif isinstance(node, ast.ClassDef): # most other api will be running through here
+            for method in node.body:
+                #print(method, dir(method))
+                if isinstance(method, ast.FunctionDef) and method.name != "__init__":
+
+                    args = [arg.arg for arg in method.args.args if arg.arg != "self"]
+
+                    if method.name[0] == "_": # if method starts with _, consider it internal
+                        continue
+
+                    # grab only the first line of the doc string
+                    comment = ast.get_docstring(method)
+                    if comment:
+                        comment = comment.split('\n')[0]
+
+                    line = ""
+                    module_name_output = module_name
+                    if module_name is None:
+                        module_name_output = node.name.lower()
+
+
+                    if csv:
+                        line = [f"{module_name_output}.{method.name}({', '.join(args)})", comment]
+                    else:
+                        line = f"{module_name_output}.{method.name}({', '.join(args)}) {comment}"
+
+                    api.append(line)
+
+    return api
+
+def get_macro(filepath):
+    """
+    Reads in the lib/autokey/macro.py and parses out classes that extend "AbstractMacro".
+    Reads the ID, TITLE and ARGS values and returns a list of the macros found
+
+    :param filepath: Filepath to read in and parse, currently only lib/autokey/macro.py would work here.
+    """
+    macro = []
+
+    with open(filepath, 'r') as f:
+        module_ast = ast.parse(f.read())
+
+    for class_node in module_ast.body:
+        var_name = ""
+        name=""
+        description=""
+        args = []
+        if isinstance(class_node, ast.ClassDef):
+            if class_node.bases and class_node.bases[0].id=="AbstractMacro":
+                for node in class_node.body:
+                    if isinstance(node, ast.Assign):
+                        var_name = node.targets[0].id
+                        
+                        if isinstance(node.value, ast.Constant):
+                            name = node.value.s
+
+                        # because TITLE is wrapped in translate it's considered a call, have to handle that differently
+                        if isinstance(node.value, ast.Call): 
+                            description = node.value.args[0].value
+
+                        if isinstance(node.value, ast.List):
+                            
+                            for arg in node.value.elts:
+                                if isinstance(arg, ast.Tuple):
+                                    for item in arg.elts:
+                                        if isinstance(item, ast.Call):
+                                            arg_description = item.args[0].value
+                                        elif isinstance(item, ast.Constant):
+                                            arg_name = item.value
+
+                                    #print(item, arg_name, arg_description)
+                                    args.append([arg_name, arg_description])
+
+                        
+                        #print(var_name, name, description, node.value)
+                        arguments = ""
+                        if args:
+                            arguments = " "
+                            for arg in args:
+                                arguments += f'{arg[0]}="{arg[1]}" '
+                        
+                        line = [f"<{name}{arguments.rstrip()}>", description]
+                
+                #print(line)
+                macro.append(line)
+
+    return macro
+
+
+
+api = []
+api += get_api("./lib/autokey/scripting/keyboard.py")
+api += get_api("./lib/autokey/scripting/mouse.py")
+api += get_api("./lib/autokey/scripting/window.py")
+api += get_api("./lib/autokey/scripting/system.py")
+api += get_api("./lib/autokey/scripting/engine.py")
+api += get_api("./lib/autokey/scripting/highlevel.py", "highlevel")
+api += get_api("./lib/autokey/scripting/abstract_clipboard.py", "clipboard")
+api += get_api("./lib/autokey/scripting/dialog_qt.py", "dialog")
+# common.py holds classes that are returned by other things, doesn't need to be autocompleted.
+#api += get_api("./lib/autokey/scripting/common.py")
+
+filename = "./lib/autokey/qtui/data/api.txt"
+print("Qt Autocomplete:", filename)
+print("\n".join(api))
+
+with open(filename, 'w') as f:
+    f.write("\n".join(api))
+
+
+
+# build out api.csv for GtkAutocomplete, writes as csv file
+csv_api = []
+csv_api += get_api("./lib/autokey/scripting/keyboard.py", csv=True)
+csv_api += get_api("./lib/autokey/scripting/mouse.py", csv=True)
+csv_api += get_api("./lib/autokey/scripting/window.py", csv=True)
+csv_api += get_api("./lib/autokey/scripting/system.py", csv=True)
+csv_api += get_api("./lib/autokey/scripting/engine.py", csv=True)
+csv_api += get_api("./lib/autokey/scripting/highlevel.py", "highlevel", csv=True)
+csv_api += get_api("./lib/autokey/scripting/abstract_clipboard.py", "clipboard", csv=True)
+csv_api += get_api("./lib/autokey/scripting/dialog_gtk.py", "dialog", csv=True)
+#csv_api += get_api("./lib/autokey/scripting/common.py", csv=True)
+
+filename = "./lib/autokey/gtkui/data/api.csv"
+print("#"*80)
+print("GTK Autocomplete:", filename)
+[print(",".join(str(x) for x in line)) for line in csv_api]
+
+with open(filename, 'w') as f:
+    writer = csv.writer(f)
+
+    for line in csv_api:
+        writer.writerow(line)
+
+
+
+macros = []
+macros+=get_macro("./lib/autokey/macro.py")
+
+filename = "./lib/autokey/gtkui/data/macros.csv"
+print("#"*80)
+print("GTK Macros:", filename)
+[print(",".join(str(x) for x in line)) for line in macros]
+
+with open(filename, 'w') as f:
+    writer = csv.writer(f)
+
+    for line in macros:
+        writer.writerow(line)

--- a/extractDoc.py
+++ b/extractDoc.py
@@ -162,6 +162,7 @@ api += get_api("./lib/autokey/scripting/engine.py")
 api += get_api("./lib/autokey/scripting/highlevel.py", "highlevel")
 api += get_api("./lib/autokey/scripting/abstract_clipboard.py", "clipboard")
 api += get_api("./lib/autokey/scripting/dialog_qt.py", "dialog")
+api += get_api("./lib/autokey/model/store.py")
 # common.py holds classes that are returned by other things, doesn't need to be autocompleted.
 #api += get_api("./lib/autokey/scripting/common.py")
 
@@ -184,6 +185,7 @@ csv_api += get_api("./lib/autokey/scripting/engine.py", csv=True)
 csv_api += get_api("./lib/autokey/scripting/highlevel.py", "highlevel", csv=True)
 csv_api += get_api("./lib/autokey/scripting/abstract_clipboard.py", "clipboard", csv=True)
 csv_api += get_api("./lib/autokey/scripting/dialog_gtk.py", "dialog", csv=True)
+csv_api += get_api("./lib/autokey/model/store.py", csv=True)
 #csv_api += get_api("./lib/autokey/scripting/common.py", csv=True)
 
 filename = "./lib/autokey/gtkui/data/api.csv"

--- a/lib/autokey/gtkui/autocomplete.py
+++ b/lib/autokey/gtkui/autocomplete.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Sam Sebastian
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+
+from gi import require_version
+import csv
+
+require_version('Gtk', '3.0')
+require_version('GtkSource', '3.0')
+
+from gi.repository import Gtk, GtkSource, GObject
+
+logger = __import__("autokey.logger").logger.get_logger(__name__)
+
+class FileCompletionProvider(GObject.GObject, GtkSource.CompletionProvider):
+
+    def __init__(self, filename, trigger="."):
+        super().__init__()
+        self.csv_items = []
+        self.name = "GTKAutocomplete"
+        self.trigger=trigger
+
+        with open(filename, 'r') as f:
+            reader = csv.reader(f)
+            for row in reader:
+                self.csv_items.append(row)
+
+
+    def do_get_name(self):
+        return self.name
+
+    def do_match(self, context):
+        return True
+
+    def do_populate(self, context):
+        proposals = []
+
+        end_iter = context.get_iter()
+        if not isinstance(end_iter, Gtk.TextIter):
+            _, end_iter = context.get_iter()
+
+        if end_iter:
+            buffer = end_iter.get_buffer()
+            line_number = end_iter.get_line()
+            line_start = buffer.get_iter_at_line(line_number)
+            line_end = line_start.copy()
+            line_end.forward_to_line_end()
+            full_line_text = buffer.get_text(line_start, line_end, False)
+            line_text = full_line_text.strip()
+
+            logger.debug(f"Current line: {line_number}, text: {line_text}")
+
+
+            for row in self.csv_items:
+                if self.trigger==".":
+                    module_name = row[0].split(".")[0]
+                    func_name = row[0].split(".")[1]
+                    #print(module_name, func_name)
+
+                if (self.trigger=="<" or (line_text in row[0] or module_name in line_text)) and len(line_text)>=1 and line_text[-1]==self.trigger:
+                    if self.trigger=="<": module_name=""
+
+                    completion_text = row[0][len(module_name)+1:]
+                    label = " ".join([completion_text, row[1]])
+
+                    item = GtkSource.CompletionItem(label=label, text=completion_text)
+                    item.set_icon_name("gtk-jump-to")
+
+                    
+                    proposals.append(item)
+
+                    if self.trigger=="<":
+                        self.name = "Insert Macro"
+                    else:
+                        self.name = row[0].split(".")[0]
+
+        context.add_proposals(self, proposals, True)

--- a/lib/autokey/gtkui/autocomplete.py
+++ b/lib/autokey/gtkui/autocomplete.py
@@ -82,11 +82,13 @@ class FileCompletionProvider(GObject.GObject, GtkSource.CompletionProvider):
                     item.set_icon_name("gtk-jump-to")
 
                     
-                    proposals.append(item)
+                    proposals.append({"func_name": func_name, "completion": item})
 
                     if self.trigger=="<":
                         self.name = "Insert Macro"
                     else:
                         self.name = row[0].split(".")[0]
 
-        context.add_proposals(self, proposals, True)
+        proposals.sort(key=lambda x: x["func_name"])
+        sorted_proposals = [p["completion"] for p in proposals]
+        context.add_proposals(self, sorted_proposals, True)

--- a/lib/autokey/gtkui/configwindow.py
+++ b/lib/autokey/gtkui/configwindow.py
@@ -42,6 +42,7 @@ locale.setlocale(locale.LC_ALL, '')
 
 
 from . import dialogs
+from .autocomplete import FileCompletionProvider
 from .settingsdialog import SettingsDialog
 
 import autokey.configmanager.configmanager as cm
@@ -476,6 +477,9 @@ class ScriptPage:
         self.editor.set_insert_spaces_instead_of_tabs(True)
         self.editor.set_tab_width(4)
 
+        self.editor_completion = self.editor.get_completion()
+        self.editor_completion.add_provider(FileCompletionProvider("./autokey/gtkui/data/api.csv"))
+
         self.ui.show_all()
 
     def load(self, theScript):
@@ -624,6 +628,10 @@ class PhrasePage(ScriptPage):
         self.buffer = GtkSource.Buffer()
         self.buffer.connect("changed", self.on_modified)
         self.editor = GtkSource.View.new_with_buffer(self.buffer)
+
+        self.editor_completion = self.editor.get_completion()
+        self.editor_completion.add_provider(FileCompletionProvider("./autokey/gtkui/data/macros.csv", "<"))
+
         scrolledWindow = builder.get_object("scrolledWindow")
         scrolledWindow.add(self.editor)
         self.promptCheckbox = builder.get_object("promptCheckbox")

--- a/lib/autokey/gtkui/data/api.csv
+++ b/lib/autokey/gtkui/data/api.csv
@@ -83,3 +83,10 @@ dialog.save_file(title),Show a Save As dialog
 "dialog.choose_directory(title, initialDir)",Show a Directory Chooser dialog
 dialog.choose_colour(title),Show a Colour Chooser dialog
 "dialog.calendar(title, format_str, date)",Show a calendar dialog
+"store.set_value(key, value)",Store a value
+store.get_value(key),Get a value
+store.remove_value(key),Remove a value
+"store.set_global_value(key, value)",Store a global value
+store.get_global_value(key),Get a global value
+store.remove_global_value(key),Remove a global value
+store.has_key(key),python 2 compatibility

--- a/lib/autokey/gtkui/data/api.csv
+++ b/lib/autokey/gtkui/data/api.csv
@@ -1,0 +1,85 @@
+"keyboard.send_keys(key_string, send_mode)",Send a sequence of keys via keyboard events as the default or via clipboard pasting.
+"keyboard.send_key(key, repeat)",Send a keyboard event
+keyboard.press_key(key),Send a key down event
+keyboard.release_key(key),Send a key up event
+"keyboard.fake_keypress(key, repeat)",Fake a keypress
+"keyboard.wait_for_keypress(key, modifiers, timeOut)",Wait for a keypress or key combination
+"keyboard.wait_for_keyevent(check, name, timeOut)","Wait for a key event, potentially accumulating the intervening characters"
+"mouse.click_relative(x, y, button)",Send a mouse click relative to the active window
+"mouse.click_relative_self(x, y, button)",Send a mouse click relative to the current mouse position
+"mouse.click_absolute(x, y, button)",Send a mouse click relative to the screen (absolute)
+"mouse.wait_for_click(button, timeOut)",Wait for a mouse click
+"mouse.move_cursor(x, y)",Move mouse cursor to xy location on screen without warping back to the start location
+"mouse.move_relative(x, y)",Move cursor relative to xy location based on the top left hand corner of the window that has input focus
+"mouse.move_relative_self(x, y)",Move cursor relative to the location of the mouse cursor
+mouse.press_button(button),Send mouse button down signal at current  location
+mouse.release_button(button),Send mouse button up signal at current location
+"mouse.select_area(startx, starty, endx, endy, button, scrollNumber, down, warp)","""Drag and Select"" for an area with the top left corner at (startx, starty)"
+mouse.get_location(),Returns the current location of the mouse.
+mouse.get_relative_location(),Returns the relative location of the mouse in the window that has input focus
+mouse.scroll_down(number),Fires the mouse button 5 signal the specified number of times.
+mouse.scroll_up(number),Fires the mouse button 4 signal the specified number of times.
+"window.wait_for_focus(title, timeOut)",Wait for window with the given title to have focus
+"window.wait_for_exist(title, timeOut, by_hex)",Wait for window with the given title to be created
+"window.activate(title, switchDesktop, matchClass, by_hex)","Activate the specified window, giving it input focus"
+"window.close(title, matchClass, by_hex)",Close the specified window gracefully
+"window.resize_move(title, xOrigin, yOrigin, width, height, matchClass, by_hex)",Resize and/or move the specified window
+"window.move_to_desktop(title, deskNum, matchClass, by_hex)",Move the specified window to the given desktop
+window.switch_desktop(deskNum),Switch to the specified desktop
+"window.set_property(title, action, prop, matchClass, by_hex)",Set a property on the given window using the specified action
+window.get_active_geometry(),Get the geometry of the currently active window. Uses the C{:ACTIVE:} function of C{wmctrl}.
+window.get_active_title(),Get the visible title of the currently active window
+window.get_active_class(),Get the class of the currently active window
+"window.center_window(title, win_width, win_height, monitor, matchClass, by_hex)",Centers the active (or window selected by title) window. Requires xrandr for getting monitor sizes and offsets.
+window.get_window_list(filter_desktop),"Returns a list of windows matching an optional desktop filter, requires C{wmctrl}!"
+window.get_window_hex(title),Returns the hexid of the first window to match title.
+"window.get_window_geometry(title, by_hex)",Uses C{wmctrl} to return the window geometry of the given window title. Returns where the location of the
+"system.exec_command(command, getOutput)",Execute a shell command
+"system.create_file(file_name, contents)",Create a file with contents
+engine.get_folder(title),Retrieve a folder by its title
+"engine.create_folder(title, parent_folder, temporary)",Create and return a new folder.
+"engine.create_phrase(folder, name, contents, abbreviations, hotkey, send_mode, window_filter, show_in_system_tray, always_prompt, temporary, replace_existing_hotkey)",Create a new text phrase inside the given folder. Use C{engine.get_folder(folder_name)} to retrieve the folder
+"engine.create_abbreviation(folder, description, abbr, contents)",DEPRECATED. Use engine.create_phrase() with appropriate keyword arguments instead.
+"engine.create_hotkey(folder, description, modifiers, key, contents)",DEPRECATED. Use engine.create_phrase() with appropriate keyword arguments instead.
+engine.run_script(description),Run an existing script using its description or path to look it up
+engine.run_script_from_macro(args),Used internally by AutoKey for phrase macros
+engine.run_system_command_from_macro(args),Used internally by AutoKey for system macros
+engine.get_script_arguments(),Get the arguments supplied to the current script via the scripting api
+engine.get_script_keyword_arguments(),Get the arguments supplied to the current script via the scripting api
+engine.get_macro_arguments(),Get the arguments supplied to the current script via its macro
+engine.set_return_value(val),Store a return value to be used by a phrase macro
+engine.get_triggered_abbreviation(),This function can be queried by a script to get the abbreviation text that triggered it’s execution.
+"engine.remove_all_temporary(folder, in_temp_parent)","Removes all temporary folders and phrases, as well as any within"
+engine.get_item_with_hotkey(hotkey),
+engine.validateAbbreviations(abbreviations),Checks if the given abbreviations are a list/iterable of strings
+"engine.check_abbreviation_unique(configmanager, abbreviations, window_filter)",Checks if the given abbreviations are unique
+"engine.check_hotkey_unique(configmanager, hotkey, window_filter)",Checks if the given hotkey is unique
+engine.isValidHotkeyType(item),Checks if the hotkey is valid.
+engine.validateHotkey(hotkey),    
+"engine.validateArguments(folder, name, contents, abbreviations, hotkey, send_mode, window_filter, show_in_system_tray, always_prompt, temporary, replace_existing_hotkey)",
+"engine.validateType(item, name, type_)","type_ may be a list, in which case if item matches"
+"highlevel.visgrep(scr, pat, tolerance)","Usage: C{visgrep(scr: str, pat: str, tolerance: int = 0) -> int}"
+highlevel.get_png_dim(filepath),Usage: C{get_png_dim(filepath:str) -> (int)}
+"highlevel.mouse_move(x, y, display)",Moves the mouse using xte C{mousemove} from xautomation
+"highlevel.mouse_rmove(x, y, display)",Moves the mouse using xte C{mousermove} command from xautomation
+"highlevel.mouse_click(button, display)",Clicks the mouse in the current location using xte C{mouseclick} from xautomation
+highlevel.mouse_pos(),Returns the current location of the mouse.
+"highlevel.click_on_pat(pat, mousebutton, offset, tolerance, restore_pos)","Requires C{imagemagick}, C{xautomation}, C{xwd}."
+"highlevel.move_to_pat(pat, offset, tolerance)",See L{click_on_pat}
+highlevel.acknowledge_gnome_notification(),Moves mouse pointer to the bottom center of the screen and clicks on it.
+clipboard.fill_clipboard(contents),Copy text into the clipboard
+clipboard.get_clipboard(),Read text from the clipboard
+clipboard.fill_selection(contents),Copy text into the X selection
+clipboard.get_selection(),Read text from the X selection
+clipboard.set_clipboard_image(path),Set clipboard to image
+"dialog.send_notification(title, message, icon)",Sends a notification using C{zenity}
+"dialog.info_dialog(title, message)",Show an information dialog
+"dialog.input_dialog(title, message, default)",Show an input dialog
+"dialog.password_dialog(title, message)",Show a password input dialog
+"dialog.list_menu(options, title, message, default)",Show a single-selection list menu
+"dialog.list_menu_multi(options, title, message, defaults)",Show a multiple-selection list menu
+dialog.open_file(title),Show an Open File dialog
+dialog.save_file(title),Show a Save As dialog
+"dialog.choose_directory(title, initialDir)",Show a Directory Chooser dialog
+dialog.choose_colour(title),Show a Colour Chooser dialog
+"dialog.calendar(title, format_str, date)",Show a calendar dialog

--- a/lib/autokey/gtkui/data/macros.csv
+++ b/lib/autokey/gtkui/data/macros.csv
@@ -1,0 +1,5 @@
+<cursor>,Position cursor
+"<script name=""Name"" args=""Arguments (comma separated)"">",Run script
+"<system command=""Command to be executed (including any arguments) - e.g. 'ls -l'"">",Run system command
+"<date format=""Format"">",Insert date
+"<file name=""File name"">",Insert file contents

--- a/lib/autokey/qtui/data/api.txt
+++ b/lib/autokey/qtui/data/api.txt
@@ -84,3 +84,10 @@ dialog.save_file(title, initialDir, fileTypes, rememberAs) Show a Save As dialog
 dialog.choose_directory(title, initialDir, rememberAs) Show a Directory Chooser dialog
 dialog.choose_colour(title) Show a Colour Chooser dialog
 dialog.calendar(title, format_str, date) Show a calendar dialog
+store.set_value(key, value) Store a value
+store.get_value(key) Get a value
+store.remove_value(key) Remove a value
+store.set_global_value(key, value) Store a global value
+store.get_global_value(key) Get a global value
+store.remove_global_value(key) Remove a global value
+store.has_key(key) python 2 compatibility

--- a/lib/autokey/qtui/data/api.txt
+++ b/lib/autokey/qtui/data/api.txt
@@ -1,54 +1,86 @@
-engine.create_abbreviation(folder, description, abbr, contents) DEPRECATED! Use create_phrase() instead, create a Phrase with an abbreviation
-engine.create_hotkey(folder, description, modifiers, key, contents) DEPRECATED! Use create_phrase() instead, create a Phrase with a hotkey
-engine.create_phrase(folder, description, contents) Create a Phrase in the given Folder, Fully configure it using the optional keyword parameters
-engine.get_folder(title) Retrieve a folder by its title
-engine.get_macro_arguments() Get the arguments supplied to the current script via its macro
-engine.run_script(description) Run an existing script using its description to look it up
-engine.set_return_value(val) Store a return value to be used by a phrase macro
-engine.get_triggered_abbreviation() Provide the typed abbreviation and trigger character, or (None, None) if not triggered by an abbreviation
-keyboard.fake_keypress(key, repeat=1) Fake a keypress
+keyboard.send_keys(key_string, send_mode) Send a sequence of keys via keyboard events as the default or via clipboard pasting.
+keyboard.send_key(key, repeat) Send a keyboard event
 keyboard.press_key(key) Send a key down event
 keyboard.release_key(key) Send a key up event
-keyboard.send_key(key, repeat=1) Send a keyboard event
-keyboard.send_keys(key_string, send_mode=keyboard.SendMode.KEYBOARD) Send a sequence of keys via keyboard events (default) or via clipboard pasting
-keyboard.wait_for_keypress(self, key, modifiers=[], timeOut=10.0) Wait for a keypress or key combination
-keyboard.SendMode Contains all valid options for the send_mode parameter
-keyboard.SendMode.KEYBOARD Type using the keyboard
-keyboard.SendMode.CB_CTRL_V Use the clipboard and paste using <Ctrl>+V
-keyboard.SendMode.CB_CTRL_SHIFT_V Use the clipboard and paste using <Ctrl>+<Shift>+V
-keyboard.SendMode.CB_SHIFT_INSERT Use the clipboard and paste using <Shift>+<Insert>
-keyboard.SendMode.SELECTION Use the X11 PRIMARY buffer / mouse selection and Paste using the middle mouse button
-mouse.click_absolute(x, y, button) Send a mouse click relative to the screen (absolute)
+keyboard.fake_keypress(key, repeat) Fake a keypress
+keyboard.wait_for_keypress(key, modifiers, timeOut) Wait for a keypress or key combination
+keyboard.wait_for_keyevent(check, name, timeOut) Wait for a key event, potentially accumulating the intervening characters
 mouse.click_relative(x, y, button) Send a mouse click relative to the active window
 mouse.click_relative_self(x, y, button) Send a mouse click relative to the current mouse position
-mouse.wait_for_click(self, button, timeOut=10.0) Wait for a mouse click
-clipboard.fill_clipboard(contents) Copy text into the clipboard
-clipboard.fill_selection(contents) Copy text into the X selection
-clipboard.get_clipboard() Read text from the clipboard
-clipboard.get_selection() Read text from the X selection
-dialog.info_dialog(title="Information", message="") Show an informational dialog.
-dialog.choose_colour(title="Select Colour") Show a Colour Chooser dialog
-dialog.choose_directory(title="Select Directory", initialDir="~", rememberAs=None, **kwargs) Show a Directory Chooser dialog
-dialog.combo_menu(options, title="Choose an option", message="Choose an option", **kwargs) Show a combobox menu
-dialog.input_dialog(title="Enter a value", message="Enter a value", default="", **kwargs) Show an input dialog
-dialog.list_menu(options, title="Choose a value", message="Choose a value", default=None, **kwargs) Show a single-selection list menu
-dialog.list_menu_multi(options, title="Choose one or more values", message="Choose one or more values", defaults=[], **kwargs) Show a multiple-selection list menu
-dialog.open_file(title="Open File", initialDir="~", fileTypes="*|All Files", rememberAs=None, **kwargs) Show an Open File dialog
-dialog.password_dialog(title="Enter password", message="Enter password", **kwargs) Show a password input dialog
-dialog.save_file(title="Save As", initialDir="~", fileTypes="*|All Files", rememberAs=None, **kwargs) Show a Save As dialog
-store.get_value(key) Get a value
-store.remove_value(key) Remove a value
-store.set_value(key, value) Store a value
-system.create_file(fileName, contents="") Create a file with contents
-system.exec_command(command, getOutput=True) Execute a shell command
-window.activate(title, switchDesktop=False, matchClass=False) Activate the specified window, giving it input focus
-window.close(title, matchClass=False) Close the specified window gracefully
-window.get_active_class() Get the class of the currently active window
-window.get_active_geometry() Get the geometry of the currently active window
-window.get_active_title() Get the visible title of the currently active window
-window.move_to_desktop(title, deskNum, matchClass=False) Move the specified window to the given desktop
-window.close(title, xOrigin=-1, yOrigin=-1, width=-1, height=-1, matchClass=False) Resize and/or move the specified window
-window.set_property(title, action, prop, matchClass=False) Set a property on the given window using the specified action
+mouse.click_absolute(x, y, button) Send a mouse click relative to the screen (absolute)
+mouse.wait_for_click(button, timeOut) Wait for a mouse click
+mouse.move_cursor(x, y) Move mouse cursor to xy location on screen without warping back to the start location
+mouse.move_relative(x, y) Move cursor relative to xy location based on the top left hand corner of the window that has input focus
+mouse.move_relative_self(x, y) Move cursor relative to the location of the mouse cursor
+mouse.press_button(button) Send mouse button down signal at current  location
+mouse.release_button(button) Send mouse button up signal at current location
+mouse.select_area(startx, starty, endx, endy, button, scrollNumber, down, warp) "Drag and Select" for an area with the top left corner at (startx, starty)
+mouse.get_location() Returns the current location of the mouse.
+mouse.get_relative_location() Returns the relative location of the mouse in the window that has input focus
+mouse.scroll_down(number) Fires the mouse button 5 signal the specified number of times.
+mouse.scroll_up(number) Fires the mouse button 4 signal the specified number of times.
+window.wait_for_focus(title, timeOut) Wait for window with the given title to have focus
+window.wait_for_exist(title, timeOut, by_hex) Wait for window with the given title to be created
+window.activate(title, switchDesktop, matchClass, by_hex) Activate the specified window, giving it input focus
+window.close(title, matchClass, by_hex) Close the specified window gracefully
+window.resize_move(title, xOrigin, yOrigin, width, height, matchClass, by_hex) Resize and/or move the specified window
+window.move_to_desktop(title, deskNum, matchClass, by_hex) Move the specified window to the given desktop
 window.switch_desktop(deskNum) Switch to the specified desktop
-window.wait_for_exist(title, timeOut=5) Wait for window with the given title to be created
-window.wait_for_focus(title, timeOut=5) Wait for window with the given title to have focus
+window.set_property(title, action, prop, matchClass, by_hex) Set a property on the given window using the specified action
+window.get_active_geometry() Get the geometry of the currently active window. Uses the C{:ACTIVE:} function of C{wmctrl}.
+window.get_active_title() Get the visible title of the currently active window
+window.get_active_class() Get the class of the currently active window
+window.center_window(title, win_width, win_height, monitor, matchClass, by_hex) Centers the active (or window selected by title) window. Requires xrandr for getting monitor sizes and offsets.
+window.get_window_list(filter_desktop) Returns a list of windows matching an optional desktop filter, requires C{wmctrl}!
+window.get_window_hex(title) Returns the hexid of the first window to match title.
+window.get_window_geometry(title, by_hex) Uses C{wmctrl} to return the window geometry of the given window title. Returns where the location of the
+system.exec_command(command, getOutput) Execute a shell command
+system.create_file(file_name, contents) Create a file with contents
+engine.get_folder(title) Retrieve a folder by its title
+engine.create_folder(title, parent_folder, temporary) Create and return a new folder.
+engine.create_phrase(folder, name, contents, abbreviations, hotkey, send_mode, window_filter, show_in_system_tray, always_prompt, temporary, replace_existing_hotkey) Create a new text phrase inside the given folder. Use C{engine.get_folder(folder_name)} to retrieve the folder
+engine.create_abbreviation(folder, description, abbr, contents) DEPRECATED. Use engine.create_phrase() with appropriate keyword arguments instead.
+engine.create_hotkey(folder, description, modifiers, key, contents) DEPRECATED. Use engine.create_phrase() with appropriate keyword arguments instead.
+engine.run_script(description) Run an existing script using its description or path to look it up
+engine.run_script_from_macro(args) Used internally by AutoKey for phrase macros
+engine.run_system_command_from_macro(args) Used internally by AutoKey for system macros
+engine.get_script_arguments() Get the arguments supplied to the current script via the scripting api
+engine.get_script_keyword_arguments() Get the arguments supplied to the current script via the scripting api
+engine.get_macro_arguments() Get the arguments supplied to the current script via its macro
+engine.set_return_value(val) Store a return value to be used by a phrase macro
+engine.get_triggered_abbreviation() This function can be queried by a script to get the abbreviation text that triggered it’s execution.
+engine.remove_all_temporary(folder, in_temp_parent) Removes all temporary folders and phrases, as well as any within
+engine.get_item_with_hotkey(hotkey) None
+engine.validateAbbreviations(abbreviations) Checks if the given abbreviations are a list/iterable of strings
+engine.check_abbreviation_unique(configmanager, abbreviations, window_filter) Checks if the given abbreviations are unique
+engine.check_hotkey_unique(configmanager, hotkey, window_filter) Checks if the given hotkey is unique
+engine.isValidHotkeyType(item) Checks if the hotkey is valid.
+engine.validateHotkey(hotkey)     
+engine.validateArguments(folder, name, contents, abbreviations, hotkey, send_mode, window_filter, show_in_system_tray, always_prompt, temporary, replace_existing_hotkey) None
+engine.validateType(item, name, type_) type_ may be a list, in which case if item matches
+highlevel.visgrep(scr, pat, tolerance) Usage: C{visgrep(scr: str, pat: str, tolerance: int = 0) -> int}
+highlevel.get_png_dim(filepath) Usage: C{get_png_dim(filepath:str) -> (int)}
+highlevel.mouse_move(x, y, display) Moves the mouse using xte C{mousemove} from xautomation
+highlevel.mouse_rmove(x, y, display) Moves the mouse using xte C{mousermove} command from xautomation
+highlevel.mouse_click(button, display) Clicks the mouse in the current location using xte C{mouseclick} from xautomation
+highlevel.mouse_pos() Returns the current location of the mouse.
+highlevel.click_on_pat(pat, mousebutton, offset, tolerance, restore_pos) Requires C{imagemagick}, C{xautomation}, C{xwd}.
+highlevel.move_to_pat(pat, offset, tolerance) See L{click_on_pat}
+highlevel.acknowledge_gnome_notification() Moves mouse pointer to the bottom center of the screen and clicks on it.
+clipboard.fill_clipboard(contents) Copy text into the clipboard
+clipboard.get_clipboard() Read text from the clipboard
+clipboard.fill_selection(contents) Copy text into the X selection
+clipboard.get_selection() Read text from the X selection
+clipboard.set_clipboard_image(path) Set clipboard to image
+dialog.send_notification(title, message, icon, timeout) Sends a passive popup (notification) using C{kdialog}
+dialog.info_dialog(title, message) Show an information dialog
+dialog.input_dialog(title, message, default) Show an input dialog
+dialog.password_dialog(title, message) Show a password input dialog
+dialog.combo_menu(options, title, message) Show a combobox menu
+dialog.list_menu(options, title, message, default) Show a single-selection list menu
+dialog.list_menu_multi(options, title, message, defaults) Show a multiple-selection list menu
+dialog.open_file(title, initialDir, fileTypes, rememberAs) Show an Open File dialog
+dialog.save_file(title, initialDir, fileTypes, rememberAs) Show a Save As dialog
+dialog.choose_directory(title, initialDir, rememberAs) Show a Directory Chooser dialog
+dialog.choose_colour(title) Show a Colour Chooser dialog
+dialog.calendar(title, format_str, date) Show a calendar dialog


### PR DESCRIPTION
Updates `extractDoc.py`, this will now generate the qt `api.txt` and two files for gtk autocompletion, `api.csv` and `macro.csv`.

Adds autocompletion to Gtk for both the phrase and script pages.

At this time I don't see any easy way to add autocompletion to the Qt phrase pages.
 