### PR TITLE
Change clipboard wording in the documentation for clarity.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -104,6 +104,7 @@ Other changes
 - Update pip installation requirements
 - Add CONTRIBUTERS.rst
 - Internal Code cleanup. The configuration handling module is split into multiple modules inside a dedicated package.
+- Change clipboard wording in the AutoKey documentation.
 - AutoKey now has a working test environment again. `pytest` based unit-tests can be launched from the source checkout using `python3 setup.py test`
 
 **New Dependencies (test-time only)**

--- a/lib/autokey/scripting/clipboard_gtk.py
+++ b/lib/autokey/scripting/clipboard_gtk.py
@@ -98,7 +98,7 @@ class GtkClipboard:
 
         Usage: C{clipboard.fill_clipboard(contents)}
 
-        @param contents: string to be placed in the selection
+        @param contents: string to be placed onto the clipboard
         """
         Gdk.threads_enter()
         if Gtk.get_major_version() >= 3:

--- a/lib/autokey/scripting/clipboard_qt.py
+++ b/lib/autokey/scripting/clipboard_qt.py
@@ -86,7 +86,7 @@ class QtClipboard:
 
         Usage: C{clipboard.fill_clipboard(contents)}
 
-        @param contents: string to be placed in the selection
+        @param contents: string to be placed onto the clipboard
         """
         self.__execAsync(self.__fillClipboard, contents)
 


### PR DESCRIPTION
* Update the wording for [the clipboard entry](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_gtk.py#L101) in the [/lib/autokey/scripting/clipboard_gtk.py](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_gtk.py) file.

* Update the wording for [the clipboard entry](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_qt.py#L89) in the [/lib/autokey/scripting/clipboard_qt.py](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_qt.py) file.
