### PR TITLE
Update GTK/Qt clipboard API documentation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -105,6 +105,7 @@ Other changes
 - Add CONTRIBUTERS.rst
 - Internal Code cleanup. The configuration handling module is split into multiple modules inside a dedicated package.
 - Change clipboard wording in the AutoKey documentation.
+- Update formatting and wording in the AutoKey GTK and Qt clipboard API documentation.
 - AutoKey now has a working test environment again. `pytest` based unit-tests can be launched from the source checkout using `python3 setup.py test`
 
 **New Dependencies (test-time only)**

--- a/lib/autokey/scripting/clipboard_gtk.py
+++ b/lib/autokey/scripting/clipboard_gtk.py
@@ -41,7 +41,7 @@ class GtkClipboard:
         """
         self.selection = Gtk.Clipboard.get(Gdk.SELECTION_PRIMARY)
         """
-        Refers to the "selection" of the clipboard or the highlighted text
+        Refers to the selection of the clipboard or the highlighted text
         """
         self.app = app
         """
@@ -74,13 +74,13 @@ class GtkClipboard:
 
     def get_selection(self):
         """
-        Read text from the X selection
+        Read text from the selection
 
-        The X selection refers to the currently highlighted text.
+        Refers to the currently-highlighted text
 
         Usage: C{clipboard.get_selection()}
 
-        @return: text contents of the mouse selection
+        @return: text contents of the selection
         @rtype: C{str}
         @raise Exception: if no text was found in the selection
         """
@@ -131,8 +131,8 @@ class GtkClipboard:
 
         Usage: C{clipboard.set_clipboard_image(path)}
 
-        @param path: Path to image file
-        @raise OSError: If path does not exist
+        @param path: path to image file
+        @raise OSError: if path does not exist
 
         """
         image_path = Path(path).expanduser()

--- a/lib/autokey/scripting/clipboard_qt.py
+++ b/lib/autokey/scripting/clipboard_qt.py
@@ -17,7 +17,7 @@ class QtClipboard:
 
     def __init__(self, app):
         """
-        Initialize the Qt version of the Clipboard
+        Initialize the Qt version of the clipboard
 
         Usage: Called when QtClipboard is imported.
 
@@ -45,7 +45,7 @@ class QtClipboard:
 
     def fill_selection(self, contents):
         """
-        Copy text into the X selection
+        Copy text into the selection
 
         Usage: C{clipboard.fill_selection(contents)}
 
@@ -66,7 +66,7 @@ class QtClipboard:
 
     def get_selection(self):
         """
-        Read text from the X selection
+        Read text from the selection
 
         Usage: C{clipboard.get_selection()}
 
@@ -82,7 +82,7 @@ class QtClipboard:
 
     def fill_clipboard(self, contents):
         """
-        Copy text into the clipboard
+        Copy text onto the clipboard
 
         Usage: C{clipboard.fill_clipboard(contents)}
 


### PR DESCRIPTION
Update formatting and wording in the AutoKey [GTK](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_gtk.py) and [Qt](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_qt.py) clipboard API documentation.
*  Fix capitalization for consistency.
* Fix punctuation.
* Remove "mouse" and "X" from selection in descriptions.
* Update reference to clipboard for accuracy.
* Update references to selection for consistency.
