### PR TITLE
Remove one reference to X in the AutoKey GTK clipboard API documentation.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -106,6 +106,7 @@ Other changes
 - Internal Code cleanup. The configuration handling module is split into multiple modules inside a dedicated package.
 - Change clipboard wording in the AutoKey documentation.
 - Update formatting and wording in the AutoKey GTK and Qt clipboard API documentation.
+- Remove one reference to X in the AutoKey GTK clipboard API documentation.
 - AutoKey now has a working test environment again. `pytest` based unit-tests can be launched from the source checkout using `python3 setup.py test`
 
 **New Dependencies (test-time only)**

--- a/lib/autokey/scripting/clipboard_gtk.py
+++ b/lib/autokey/scripting/clipboard_gtk.py
@@ -50,7 +50,7 @@ class GtkClipboard:
 
     def fill_selection(self, contents):
         """
-        Copy text into the X selection
+        Copy text into the selection
 
         Usage: C{clipboard.fill_selection(contents)}
 


### PR DESCRIPTION
This is the removal of the one reference to **X** in [line 53](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_gtk.py#L53) that I had missed in the previous pull request.
