### PR TITLE
Remove mouse reference from one line of the clipboard_qt file.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -107,6 +107,7 @@ Other changes
 - Change clipboard wording in the AutoKey documentation.
 - Update formatting and wording in the AutoKey GTK and Qt clipboard API documentation.
 - Remove one reference to X in the AutoKey GTK clipboard API documentation.
+- Remove one reference to mouse in the AutoKey Qt clipboard API documentation.
 - AutoKey now has a working test environment again. `pytest` based unit-tests can be launched from the source checkout using `python3 setup.py test`
 
 **New Dependencies (test-time only)**

--- a/lib/autokey/scripting/clipboard_qt.py
+++ b/lib/autokey/scripting/clipboard_qt.py
@@ -70,7 +70,7 @@ class QtClipboard:
 
         Usage: C{clipboard.get_selection()}
 
-        @return: text contents of the mouse selection
+        @return: text contents of the selection
         @rtype: C{str}
         """
         self.__execAsync(self.__getSelection)


### PR DESCRIPTION
There was a mouse still crawling around [on line 73 of the **clipboard_qt** file](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/clipboard_qt.py#L73), so I got rid of it.
