### PR TITLE
Add the Environment section to the .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,15 @@ __pycache__
 *.pyc
 .tox/
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
 # IDE's
 .idea
 .vscode

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Important misc changes
 - Fix Qt reference and update the wording in reference to KDE and Qt in the **autokey-qt.1** man page.
 - Update the date and remove excess wording in the **autokey-gtk.1** and **autokey-qt.1** man pages.
 - Update the date in the **autokey-run.1** man page.
+- Add the "Environment" section to the .gitignore file.
 
 Features
 ---------


### PR DESCRIPTION
Add the Environment section to the .gitignore file so that virtual environments (which we will soon be required to use and may already use) will be ignored by GitHub.
