### PR TITLE
Remove special handling of ignoreCase and matchCase settings (#588)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Important misc changes
 - Add the "Environment" section to the .gitignore file.
 - Update the help menu, deprecating one entry, adding several entries, updating existing wording, and sorting the entries.
 - Update the logger by removing an unneeded space and making the **cutelog** reference match the new command-line switch for it in the help menu.
+- Remove special handling of ignoreCase and matchCase options in abbreviation settings dialogs, allowing phrases to trigger on any input case while matching input case in the output (see #588).
 
 Features
 ---------

--- a/lib/autokey/gtkui/data/abbrsettings.xml
+++ b/lib/autokey/gtkui/data/abbrsettings.xml
@@ -246,7 +246,6 @@
                     <property name="halign">start</property>
                     <property name="use_action_appearance">False</property>
                     <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="on_matchCaseCheckbox_stateChanged" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -264,7 +263,6 @@
                     <property name="halign">start</property>
                     <property name="use_action_appearance">False</property>
                     <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="on_ignoreCaseCheckbox_stateChanged" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/lib/autokey/gtkui/data/abbrsettings.xml
+++ b/lib/autokey/gtkui/data/abbrsettings.xml
@@ -238,7 +238,7 @@
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="matchCaseCheckbox">
-                    <property name="label" translatable="yes">Match phrase case to typed abbreviation</property>
+                    <property name="label" translatable="yes">Match output case to abbreviation case</property>
                     <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -255,7 +255,7 @@
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="ignoreCaseCheckbox">
-                    <property name="label" translatable="yes">Ignore case of typed abbreviation</property>
+                    <property name="label" translatable="yes">Trigger for any abbreviation case</property>
                     <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>

--- a/lib/autokey/gtkui/data/abbrsettings.xml
+++ b/lib/autokey/gtkui/data/abbrsettings.xml
@@ -238,7 +238,7 @@
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="matchCaseCheckbox">
-                    <property name="label" translatable="yes">Match output case to abbreviation case</property>
+                    <property name="label" translatable="yes">Match output case to typed abbreviation case</property>
                     <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -255,7 +255,7 @@
                 </child>
                 <child>
                   <object class="GtkCheckButton" id="ignoreCaseCheckbox">
-                    <property name="label" translatable="yes">Trigger for any abbreviation case</property>
+                    <property name="label" translatable="yes">Accept any typed abbreviation case</property>
                     <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>

--- a/lib/autokey/gtkui/dialogs.py
+++ b/lib/autokey/gtkui/dialogs.py
@@ -396,14 +396,6 @@ class AbbrSettingsDialog(DialogBase):
     def on_abbrList_cursorchanged(self, widget, data=None):
         pass
 
-    def on_ignoreCaseCheckbox_stateChanged(self, widget, data=None):
-        if not self.ignoreCaseCheckbox.get_active():
-            self.matchCaseCheckbox.set_active(False)
-
-    def on_matchCaseCheckbox_stateChanged(self, widget, data=None):
-        if self.matchCaseCheckbox.get_active():
-            self.ignoreCaseCheckbox.set_active(True)
-
     def on_immediateCheckbox_stateChanged(self, widget, data=None):
         if self.immediateCheckbox.get_active():
             self.omitTriggerCheckbox.set_active(False)

--- a/lib/autokey/qtui/dialogs/abbrsettings.py
+++ b/lib/autokey/qtui/dialogs/abbrsettings.py
@@ -104,14 +104,6 @@ class AbbrSettingsDialog(*ui_common.inherits_from_ui_file_with_name("abbrsetting
     def on_abbrListWidget_itemDoubleClicked(self, item):
         self.abbrListWidget.editItem(item)
 
-    def on_ignoreCaseCheckbox_stateChanged(self, state):
-        if not state:
-            self.matchCaseCheckbox.setChecked(False)
-
-    def on_matchCaseCheckbox_stateChanged(self, state):
-        if state:
-            self.ignoreCaseCheckbox.setChecked(True)
-
     def on_immediateCheckbox_stateChanged(self, state):
         if state:
             self.omitTriggerCheckbox.setChecked(False)

--- a/lib/autokey/qtui/resources/ui/abbrsettings.ui
+++ b/lib/autokey/qtui/resources/ui/abbrsettings.ui
@@ -65,7 +65,7 @@ If unchecked, the abbreviation text is kept.</string>
    <item row="5" column="2" colspan="3">
     <widget class="QCheckBox" name="ignoreCaseCheckbox">
      <property name="text">
-      <string>Trigger for any abbreviation case</string>
+      <string>Accept any typed abbreviation case</string>
      </property>
     </widget>
    </item>
@@ -79,7 +79,7 @@ If unchecked, the abbreviation text is kept.</string>
    <item row="4" column="2" colspan="3">
     <widget class="QCheckBox" name="matchCaseCheckbox">
      <property name="text">
-      <string>Match output case to abbreviation case</string>
+      <string>Match output case to typed abbreviation case</string>
      </property>
     </widget>
    </item>

--- a/lib/autokey/qtui/resources/ui/abbrsettings.ui
+++ b/lib/autokey/qtui/resources/ui/abbrsettings.ui
@@ -65,7 +65,7 @@ If unchecked, the abbreviation text is kept.</string>
    <item row="5" column="2" colspan="3">
     <widget class="QCheckBox" name="ignoreCaseCheckbox">
      <property name="text">
-      <string>Ignore case of typed abbreviation</string>
+      <string>Trigger for any abbreviation case</string>
      </property>
     </widget>
    </item>
@@ -79,7 +79,7 @@ If unchecked, the abbreviation text is kept.</string>
    <item row="4" column="2" colspan="3">
     <widget class="QCheckBox" name="matchCaseCheckbox">
      <property name="text">
-      <string>Match phrase case to typed abbreviation</string>
+      <string>Match output case to abbreviation case</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Further to discussion at #588, this PR removes the code from the GTK UI that keeps the ignoreCase and matchCase settings in sync. I haven't done the Qt UI yet, but I can if the changes make sense.