### PR TITLE
Update the help menu and logger to satisfy part of issue #845

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,8 @@ Important misc changes
 - Update the date and remove excess wording in the **autokey-gtk.1** and **autokey-qt.1** man pages.
 - Update the date in the **autokey-run.1** man page.
 - Add the "Environment" section to the .gitignore file.
+- Update the help menu, deprecating one entry, adding several entries, updating existing wording, and sorting the entries.
+- Update the logger by removing an unneeded space and making the **cutelog** reference match the new command-line switch for it in the help menu.
 
 Features
 ---------

--- a/lib/autokey/argument_parser.py
+++ b/lib/autokey/argument_parser.py
@@ -28,43 +28,45 @@ Namespace = NamedTuple("Namespace", [
     # Mock Namespace that mimics the object returned by parse_args() and should have the same signature.
     # Used to provide better static type checking inside the IDE. Can also be used for unit testing.
     # TODO: Convert to a class when the minimum Python version is risen to >= 3.6.
-    ("verbose", bool),
     ("configure", bool),
-    ("cutelog_integration", bool),
+    ("cutelog", bool),
+    ("mouse", bool),
+    ("verbose", bool),
+    ("version", bool),
 ])
 
 
 def _generate_argument_parser() -> argparse.ArgumentParser:
     """Generates an ArgumentParser for AutoKey"""
-    parser = argparse.ArgumentParser(description="Desktop automation ")
-    parser.add_argument(
-        "-l", "--verbose",
-        action="store_true",
-        help="Enable verbose logging"
-    )
+    parser = argparse.ArgumentParser(description="desktop automation ")
     parser.add_argument(
         "-c", "--configure",
         action="store_true",
         dest="show_config_window",
-        help="Show the configuration window on startup"
-    )
-    # %(prog)s substitution only works for installations. It shows "__main__.py", if run from the source tree.
-    parser.add_argument(
-        "-V", "--version",
-        action="version",
-        version="%(prog)s Version {}".format(autokey.common.VERSION)
+        help="open the AutoKey main window"
     )
     parser.add_argument(
-        "--cutelog-integration",
+        "-C", "--cutelog",
         action="store_true",
-        help="Connect to a locally running cutelog instance with default settings to display the full program log. "
-             "See https://github.com/busimus/cutelog"
+        help="connect to a local default cutelog instance to display the full program log"
     )
     parser.add_argument(
         "-m", "--mouse",
         action="store_true",
         dest="mouse_logging",
-        help="Similar to -l/--verbose but includes mouse button events"
+        help="enable verbose logging including mouse button events"
+    )
+    parser.add_argument(
+        "-v", "--verbose", "-l",
+        action="store_true",
+        help="enable verbose logging (-l is deprecated)"
+    )
+    # %(prog)s substitution only works for installations. It shows "__main__.py", if run from the source tree.
+    parser.add_argument(
+        "-V", "--version",
+        action="version",
+        help="print the current AutoKey version to standard output",
+        version="%(prog)s Version {}".format(autokey.common.VERSION)
     )
     return parser
 
@@ -76,4 +78,5 @@ def parse_args() -> Namespace:
     """
     parser = _generate_argument_parser()
     args = parser.parse_args()
+
     return args

--- a/lib/autokey/logger.py
+++ b/lib/autokey/logger.py
@@ -51,13 +51,13 @@ def configure_root_logger(args: Namespace):
         logging_level = logging.DEBUG
     if args.mouse_logging:
         logging_level = 9
-    
+
     stdout_stream_handler.setLevel(logging_level)
     stdout_stream_handler.setFormatter(logging.Formatter(LOG_FORMAT))
 
     root_logger.addHandler(stdout_stream_handler)
     root_logger.addHandler(file_handler)
-    if args.cutelog_integration:
+    if args.cutelog:
         socket_handler = logging.handlers.SocketHandler("127.0.0.1", 19996)  # default listening address
         root_logger.addHandler(socket_handler)
         root_logger.info(f"""Connected logger "{root_logger.name}" to local log server.""")


### PR DESCRIPTION
Update the help menu by making these changes in the [argument_parser.py](https://github.com/autokey/autokey/blob/develop/lib/autokey/argument_parser.py) file:
* Add new entries to the Mock Namespace.
* Change parser description case.
* Update some help-text wording.
* Add the **cutelog** command-line switch.
* Change the existing **cutelog** command-line switch.
* Add the **verbose** command-line switches.
* Deprecate one **verbose** command-line switch.
* Add the **version** command-line switches.
* Sort the command-line switches alphabetically.

Remove unneeded space and update the **cutelog** reference in the [logger.py](https://github.com/autokey/autokey/blob/develop/lib/autokey/logger.py) file to match the updated **cutelog** reference in the help menu.
