### PR TITLE
Update and add to the GTK and Qt man pages.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Important misc changes
 - Add the "Environment" section to the .gitignore file.
 - Update the help menu, deprecating one entry, adding several entries, updating existing wording, and sorting the entries.
 - Update the logger by removing an unneeded space and making the **cutelog** reference match the new command-line switch for it in the help menu.
+- Update and add to the GTK and Qt man pages (major overhaul with current command-line switches and lots more information).
 
 Features
 ---------

--- a/doc/man/autokey-gtk.1
+++ b/doc/man/autokey-gtk.1
@@ -1,9 +1,14 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
+.\" Please adjust this date whenever revising the man page:
+.TH AUTOKEY-GTK "1" "May 15, 2023"
+.\"
 .\" First parameter, NAME, should be all caps.
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection.
 .\" Other parameters are allowed: see man(7), man(1).
-.TH AUTOKEY-GTK "1" "April 19, 2023"
-.\" Please adjust this date whenever revising the man page.
+.\"
+.\" TeX users may be more comfortable with the \fB<whatever>\fR and
+.\" \fI<whatever>\fR escape sequences to invoke bold-face or italics,
+.\" respectively.
 .\"
 .\" Some roff macros for reference:
 .\" .nh        disable hyphenation
@@ -16,53 +21,95 @@
 .\" .sp <n>    insert n+1 empty lines
 .\" For man-page-specific macros, see man(7).
 .SH NAME
-autokey-gtk \- keyboard automation utility for GNOME and GTK
+autokey-gtk \- keyboard and mouse automation utility for GNOME and GTK
 .SH SYNOPSIS
-.B autokey-gtk
-.RI [ options ]
+\fBautokey-gtk\fR [\fIoptions\fR]
+
 .SH DESCRIPTION
-This manual page briefly documents the \fBautokey-gtk\fP command.
-.PP
-.\" TeX users may be more comfortable with the \fB<whatever>\fP and
-.\" \fI<whatever>\fP escape sequences to invoke bold-face or italics,
-.\" respectively.
-\fBautokey-qt\fP is a desktop automation utility for Linux and X11
-that's customized for use in the GNOME and GTK environments. AutoKey
-allows for the automation of virtually any task by responding to typed
-abbreviations and hotkeys. It provides a full-featured GUI to make it
-highly-accessible for novices and a scripting interface to offer the
+\fBautokey-gtk\fR is a desktop automation utility for Linux and X11 
+that's customized for use with GNOME and GTK. AutoKey allows for the 
+automation of virtually any task by responding to typed abbreviations, 
+triggers, and hotkeys. It provides a full-featured GUI to make it 
+highly-accessible for novices and a scripting interface to offer the 
 full flexibility and power of the Python language.
-.PP
-See the online wiki at https://github.com/autokey/autokey/wiki for more
-information.
 .SH OPTIONS
-This program follows the usual GNU command-line syntax in which long
-options start with two dashes (`--').
-A summary of options is included below.
+This program follows the usual GNU command-line syntax with two dashes 
+used for long options. A summary of options is included below.
 .TP
 .B \-c, \-\-configure
 Open the AutoKey main window.
 .TP
-.B \-\-cutelog-integration
-Connect to a locally-running \fBcutelog\fP instance with default
-settings to display the full program log.
-.br
-See the \fBcutelog\fP GitHub page at https://github.com/busimus/cutelog
-for more information.
+.B \-C, \-\-cutelog
+Connect to a local default \fBcutelog\fR instance to display the full 
+program log.
 .TP
 .B \-h, \-\-help
 Show a summary of all options.
 .TP
-.B \-l, \-\-verbose
-Enable verbose (debug) logging.
-.TP
 .B \-m, \-\-mouse
-Enable verbose (debug) logging that includes mouse-button events.
+Enable verbose logging that includes mouse-button events.
+.TP
+.B \-v, \-\-verbose, \-l
+Enable verbose logging (\fB-l\fR is deprecated).
 .TP
 .B \-V, \-\-version
-Print the current AutoKey version to standard output and then exit.
+Print the current AutoKey version to standard output.
 .SH AUTHOR
-AutoKey was written by Chris Dekter and was loosely based on a script by
-Sam Peterson.
-.PP
-This manual page was written by Chris Dekter <cdekter@gmail.com>.
+AutoKey was written by Chris Dekter <cdekter@gmail.com> and was loosely 
+based on a script by Sam Peterson.
+.SH SEE ALSO
+.TP
+\fBpython\fR(1), \fBregex\fR(3), \fBregex\fR(7), \fBwmctrl\fR(1), \fBxautomation\fR(7), \fBxdotool\fR(1), \fBxmodmap\fR(1), \fBzenity\fR(1)
+.TP
+\fBRelated software:\fR
+.RS
+.IP \[bu] 2
+\fBcutelog:\fR https://github.com/busimus/cutelog
+.IP \[bu] 2
+\fBXKB:\fR https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Config.html
+.RE
+.TP
+\fBSimilar software in other operating systems:\fR
+.RS
+.IP \[bu] 2
+\fBAutoHotKey\fR is a free and open-source tool available for Micosoft
+Windows users.
+.IP \[bu] 2
+\fBAutomator\fR is a default Apple tool.
+.IP \[bu] 2
+\fBText Replacement\fR is a default Apple tool.
+.RE
+.TP
+\fBAutoKey web pages:\fR
+.RS
+.IP \[bu] 2
+\fBDocumentation:\fR
+.RS
+.IP \[bu] 2
+\fBAutoKey 0.95.0 through 0.95.10:\fR https://autokey.github.io/autokey/index.html
+.IP \[bu] 2
+\fBAutoKey 0.96.0:\fR https://autokey.github.io/index.html
+.RE
+.IP \[bu] 2
+\fBHome:\fR https://github.com/autokey/autokey
+.IP \[bu] 2
+\fBIssues:\fR https://github.com/autokey/autokey/issues
+.IP \[bu] 2
+\fBSocial:\fR
+.RS
+.IP \[bu] 2
+\fBDiscord:\fR https://github.com/autokey/autokey/wiki/Discord
+.IP \[bu] 2
+\fBDiscussions:\fR https://github.com/autokey/autokey/discussions
+.IP \[bu] 2
+\fBGitter:\fR https://github.com/autokey/autokey/wiki/Gitter
+.IP \[bu] 2
+\fBGoogle Groups:\fR https://github.com/autokey/autokey/wiki/Google-Groups
+.IP \[bu] 2
+\fBReddit:\fR https://github.com/autokey/autokey/wiki/Reddit
+.IP \[bu] 2
+\fBStackExchange:\fR https://github.com/autokey/autokey/wiki/StackExchange
+.RE
+.IP \[bu] 2
+\fBWiki:\fR https://github.com/autokey/autokey/wiki
+.RE

--- a/doc/man/autokey-qt.1
+++ b/doc/man/autokey-qt.1
@@ -1,9 +1,14 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
+.\" Please adjust this date whenever revising the man page:
+.TH AUTOKEY-QT "1" "May 15, 2023"
+.\"
 .\" First parameter, NAME, should be all caps.
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection.
 .\" Other parameters are allowed: see man(7), man(1).
-.TH AUTOKEY-QT "1" "April 19, 2023"
-.\" Please adjust this date whenever revising the man page.
+.\"
+.\" TeX users may be more comfortable with the \fB<whatever>\fR and
+.\" \fI<whatever>\fR escape sequences to invoke bold-face or italics,
+.\" respectively.
 .\"
 .\" Some roff macros for reference:
 .\" .nh        disable hyphenation
@@ -16,53 +21,97 @@
 .\" .sp <n>    insert n+1 empty lines
 .\" For man-page-specific macros, see man(7).
 .SH NAME
-autokey-qt \- keyboard automation utility for KDE and Qt
+autokey-qt \- keyboard and mouse automation utility for KDE and Qt
 .SH SYNOPSIS
-.B autokey-qt
-.RI [ options ]
+\fBautokey-qt\fR [\fIoptions\fR]
+
 .SH DESCRIPTION
-This manual page briefly documents the \fBautokey-qt\fP command.
-.PP
-.\" TeX users may be more comfortable with the \fB<whatever>\fP and
-.\" \fI<whatever>\fP escape sequences to invoke bold-face or italics,
-.\" respectively.
-\fBautokey-qt\fP is a desktop automation utility for Linux and X11
-that's customized for use with KDE and Qt. AutoKey allows for the
-automation of virtually any task by responding to typed abbreviations
-and hotkeys. It provides a full-featured GUI to make it
-highly-accessible for novices and a scripting interface to offer the
+\fBautokey-qt\fR is a desktop automation utility for Linux and X11 
+that's customized for use with KDE and Qt. AutoKey allows for the 
+automation of virtually any task by responding to typed abbreviations, 
+triggers, and hotkeys. It provides a full-featured GUI to make it 
+highly-accessible for novices and a scripting interface to offer the 
 full flexibility and power of the Python language.
-.PP
-See the online wiki at https://github.com/autokey/autokey/wiki for more
-information.
 .SH OPTIONS
-This program follows the usual GNU command-line syntax in which long
-options start with two dashes (`--').
-A summary of options is included below.
+This program follows the usual GNU command-line syntax with two dashes 
+used for long options. A summary of options is included below.
 .TP
 .B \-c, \-\-configure
 Open the AutoKey main window.
 .TP
-.B \-\-cutelog-integration
-Connect to a locally-running \fBcutelog\fP instance with default
-settings to display the full program log.
-.br
-See the \fBcutelog\fP GitHub page at https://github.com/busimus/cutelog
-for more information.
+.B \-C, \-\-cutelog
+Connect to a local default \fBcutelog\fR instance to display the full 
+program log.
 .TP
 .B \-h, \-\-help
 Show a summary of all options.
 .TP
-.B \-l, \-\-verbose
-Enable verbose (debug) logging.
-.TP
 .B \-m, \-\-mouse
-Enable verbose (debug) logging that includes mouse-button events.
+Enable verbose logging that includes mouse-button events.
+.TP
+.B \-v, \-\-verbose, \-l
+Enable verbose logging (\fB-l\fR is deprecated).
 .TP
 .B \-V, \-\-version
-Print the current AutoKey version to standard output and then exit.
+Print the current AutoKey version to standard output.
 .SH AUTHOR
-AutoKey was written by Chris Dekter and was loosely based on a script by
-Sam Peterson.
-.PP
-This manual page was written by Chris Dekter <cdekter@gmail.com>.
+AutoKey was written by Chris Dekter <cdekter@gmail.com> and was loosely 
+based on a script by Sam Peterson.
+.SH SEE ALSO
+.TP
+\fBpython\fR(1), \fBregex\fR(3), \fBregex\fR(7), \fBwmctrl\fR(1), \fBxautomation\fR(7), \fBxdotool\fR(1), \fBxmodmap\fR(1)
+.TP
+\fBRelated software:\fR
+.RS
+.IP \[bu] 2
+\fBcutelog:\fR https://github.com/busimus/cutelog
+.IP \[bu] 2
+\fBKDialog:\fR https://github.com/KDE/kdialog
+.IP \[bu] 2
+\fBXKB:\fR https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Config.html
+.RE
+.TP
+\fBSimilar software in other operating systems:\fR
+.RS
+.IP \[bu] 2
+\fBAutoHotKey\fR is a free and open-source tool available for Micosoft
+Windows users.
+.IP \[bu] 2
+\fBAutomator\fR is a default Apple tool.
+.IP \[bu] 2
+\fBText Replacement\fR is a default Apple tool.
+.RE
+.TP
+\fBAutoKey web pages:\fR
+.RS
+.IP \[bu] 2
+\fBDocumentation:\fR
+.RS
+.IP \[bu] 2
+\fBAutoKey 0.95.0 through 0.95.10:\fR https://autokey.github.io/autokey/index.html
+.IP \[bu] 2
+\fBAutoKey 0.96.0:\fR https://autokey.github.io/index.html
+.RE
+.IP \[bu] 2
+\fBHome:\fR https://github.com/autokey/autokey
+.IP \[bu] 2
+\fBIssues:\fR https://github.com/autokey/autokey/issues
+.IP \[bu] 2
+\fBSocial:\fR
+.RS
+.IP \[bu] 2
+\fBDiscord:\fR https://github.com/autokey/autokey/wiki/Discord
+.IP \[bu] 2
+\fBDiscussions:\fR https://github.com/autokey/autokey/discussions
+.IP \[bu] 2
+\fBGitter:\fR https://github.com/autokey/autokey/wiki/Gitter
+.IP \[bu] 2
+\fBGoogle Groups:\fR https://github.com/autokey/autokey/wiki/Google-Groups
+.IP \[bu] 2
+\fBReddit:\fR https://github.com/autokey/autokey/wiki/Reddit
+.IP \[bu] 2
+\fBStackExchange:\fR https://github.com/autokey/autokey/wiki/StackExchange
+.RE
+.IP \[bu] 2
+\fBWiki:\fR https://github.com/autokey/autokey/wiki
+.RE


### PR DESCRIPTION
This is a major overhaul of the GTK and Qt man pages with these changes:
* Move the date to the top of the document.
* Update the date.
* Move TeX instructions up with the rest of the instructions.
* Add text to the **NAME** section.
* Reformat the **SYNOPSIS** section.
* Reformat the **DESCRIPTION** section.
* Remove unnecessary information from the **DESCRIPTION** section.
* Update the text in the **DESCRIPTION** section.
* Move the wiki link from the **DESCRIPTION** section to the **SEE ALSO** section.
* Update the introductory text in the **OPTIONS** section.
* Add short command-line switch to the **cutelog** option.
* Rename long command-line switch in the **cutelog** option
* Reformat the **cutelog** option.
* Update the text in the **cutelog** option's description.
* Move the **cutelog** link from the **OPTIONS** section to the **SEE ALSO** section.
* Update the text in the **mouse** option's description.
* Add short command-line switch to the **verbose** option.
* Deprecate the -l command-line switch for the **verbose** option.
* Update the text in the **verbose** option's description.
* Update the text in the **version** option's description.
* Sort the **OPTIONS** section alphabetically.
* Remove man-page-authorship attribution from the **AUTHOR** section.
* Update the text in the **AUTHOR** section.
* Add the **SEE ALSO** section.

Also, only the **Qt** man page contains a reference to **KDialog** and only the **GTK** man page contains a reference to **Zenity**.
