### PR TITLE
Update the GTK and Qt man pages.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Important misc changes
 - Update the logger by removing an unneeded space and making the **cutelog** reference match the new command-line switch for it in the help menu.
 - Remove special handling of ignoreCase and matchCase options in abbreviation settings dialogs, allowing phrases to trigger on any input case while matching input case in the output (see #588).
 - Update the GTK and Qt man pages.
+- Update date, formatting, and NAME section in the GTK and Qt man pages.
 
 Features
 ---------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Important misc changes
 - Update the help menu, deprecating one entry, adding several entries, updating existing wording, and sorting the entries.
 - Update the logger by removing an unneeded space and making the **cutelog** reference match the new command-line switch for it in the help menu.
 - Remove special handling of ignoreCase and matchCase options in abbreviation settings dialogs, allowing phrases to trigger on any input case while matching input case in the output (see #588).
+- Update the GTK and Qt man pages.
 
 Features
 ---------

--- a/doc/man/autokey-gtk.1
+++ b/doc/man/autokey-gtk.1
@@ -1,6 +1,6 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
 .\" Please adjust this date whenever revising the man page:
-.TH AUTOKEY-GTK "1" "June 22, 2023"
+.TH AUTOKEY-GTK "1" "June 25, 2023"
 .\"
 .\" First parameter, NAME, should be all caps.
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection.
@@ -20,10 +20,14 @@
 .\" .br        insert line break
 .\" .sp <n>    insert n+1 empty lines
 .\" For man-page-specific macros, see man(7).
+
 .SH NAME
-\fBautokey-gtk\fR  \- desktop/script-automation utility for GNOME
+\fBautokey-gtk\fR  \- desktop/script-automation utility with a 
+GTK-based graphical interface
+
 .SH SYNOPSIS
 \fBautokey-gtk\fR -[\fIc|C|h|m|v|V\fR]
+
 .SH DESCRIPTION
 \fBAutoKey\fR is a set of command-line and GUI applications using GTK 
 or Qt that can be run in a variety of ways as a 
@@ -32,6 +36,7 @@ allows for the automation of virtually any task by responding to typed
 abbreviations and hotkeys. It provides a full-featured GUI for setting 
 up automatic text insertions or replacements and a scripting interface 
 for access to the flexibility and power of the Python language.
+
 .SH OPTIONS
 This program follows the usual GNU command-line syntax with two dashes 
 used for long options. A summary of options is included below.
@@ -54,9 +59,11 @@ Enable verbose logging (\fB-l\fR is deprecated).
 .TP
 .B \-V, \-\-version
 Print the current AutoKey version to standard output.
+
 .SH AUTHOR
 AutoKey was written by Chris Dekter <cdekter@gmail.com> and was loosely 
 based on a script by Sam Peterson.
+
 .SH SEE ALSO
 .TP
 \fBautokey-qt\fR(1), \fBautokey-run\fR(1), \fBpython\fR(1), \fBwmctrl\fR(1), \fBxautomation\fR(7), \fBxdotool\fR(1), \fBxmodmap\fR(1), \fBzenity\fR(1)

--- a/doc/man/autokey-gtk.1
+++ b/doc/man/autokey-gtk.1
@@ -1,9 +1,14 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
+.\" Please adjust this date whenever revising the man page:
+.TH AUTOKEY-GTK "1" "June 22, 2023"
+.\"
 .\" First parameter, NAME, should be all caps.
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection.
 .\" Other parameters are allowed: see man(7), man(1).
-.TH AUTOKEY-GTK "1" "April 19, 2023"
-.\" Please adjust this date whenever revising the man page.
+.\"
+.\" TeX users may be more comfortable with the \fB<whatever>\fR and
+.\" \fI<whatever>\fR escape sequences to invoke bold-face or italics,
+.\" respectively.
 .\"
 .\" Some roff macros for reference:
 .\" .nh        disable hyphenation
@@ -16,53 +21,99 @@
 .\" .sp <n>    insert n+1 empty lines
 .\" For man-page-specific macros, see man(7).
 .SH NAME
-autokey-gtk \- keyboard automation utility for GNOME and GTK
+\fBautokey-gtk\fR  \- desktop/script-automation utility for GNOME
 .SH SYNOPSIS
-.B autokey-gtk
-.RI [ options ]
+\fBautokey-gtk\fR -[\fIc|C|h|m|v|V\fR]
 .SH DESCRIPTION
-This manual page briefly documents the \fBautokey-gtk\fP command.
-.PP
-.\" TeX users may be more comfortable with the \fB<whatever>\fP and
-.\" \fI<whatever>\fP escape sequences to invoke bold-face or italics,
-.\" respectively.
-\fBautokey-qt\fP is a desktop automation utility for Linux and X11
-that's customized for use in the GNOME and GTK environments. AutoKey
-allows for the automation of virtually any task by responding to typed
-abbreviations and hotkeys. It provides a full-featured GUI to make it
-highly-accessible for novices and a scripting interface to offer the
-full flexibility and power of the Python language.
-.PP
-See the online wiki at https://github.com/autokey/autokey/wiki for more
-information.
+\fBAutoKey\fR is a set of command-line and GUI applications using GTK 
+or Qt that can be run in a variety of ways as a 
+desktop/script-automation utility for Linux and X11. \fBAutoKey\fR 
+allows for the automation of virtually any task by responding to typed 
+abbreviations and hotkeys. It provides a full-featured GUI for setting 
+up automatic text insertions or replacements and a scripting interface 
+for access to the flexibility and power of the Python language.
 .SH OPTIONS
-This program follows the usual GNU command-line syntax in which long
-options start with two dashes (`--').
-A summary of options is included below.
+This program follows the usual GNU command-line syntax with two dashes 
+used for long options. A summary of options is included below.
 .TP
 .B \-c, \-\-configure
 Open the AutoKey main window.
 .TP
-.B \-\-cutelog-integration
-Connect to a locally-running \fBcutelog\fP instance with default
-settings to display the full program log.
-.br
-See the \fBcutelog\fP GitHub page at https://github.com/busimus/cutelog
-for more information.
+.B \-C, \-\-cutelog
+Connect to a local default \fBcutelog\fR instance to display the full 
+program log.
 .TP
 .B \-h, \-\-help
 Show a summary of all options.
 .TP
-.B \-l, \-\-verbose
-Enable verbose (debug) logging.
-.TP
 .B \-m, \-\-mouse
-Enable verbose (debug) logging that includes mouse-button events.
+Enable verbose logging that includes mouse-button events.
+.TP
+.B \-v, \-\-verbose, \-l
+Enable verbose logging (\fB-l\fR is deprecated).
 .TP
 .B \-V, \-\-version
-Print the current AutoKey version to standard output and then exit.
+Print the current AutoKey version to standard output.
 .SH AUTHOR
-AutoKey was written by Chris Dekter and was loosely based on a script by
-Sam Peterson.
-.PP
-This manual page was written by Chris Dekter <cdekter@gmail.com>.
+AutoKey was written by Chris Dekter <cdekter@gmail.com> and was loosely 
+based on a script by Sam Peterson.
+.SH SEE ALSO
+.TP
+\fBautokey-qt\fR(1), \fBautokey-run\fR(1), \fBpython\fR(1), \fBwmctrl\fR(1), \fBxautomation\fR(7), \fBxdotool\fR(1), \fBxmodmap\fR(1), \fBzenity\fR(1)
+.TP
+\fBRelated software:\fR
+.RS
+.IP \[bu] 2
+\fBcutelog:\fR https://github.com/busimus/cutelog
+.IP \[bu] 2
+\fBRegular expression syntax:\fR https://docs.python.org/3/library/re.html
+.IP \[bu] 2
+\fBRegular expression tutorial:\fR https://docs.python.org/3/howto/regex.html
+.IP \[bu] 2
+\fBXKB:\fR https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Config.html
+.RE
+.TP
+\fBSimilar software in other operating systems:\fR
+.RS
+.IP \[bu] 2
+\fBAutoHotKey\fR is a free and open-source tool available for Micosoft
+Windows users.
+.IP \[bu] 2
+\fBAutomator\fR is a default Apple tool.
+.IP \[bu] 2
+\fBText Replacement\fR is a default Apple tool.
+.RE
+.TP
+\fBAutoKey web pages:\fR
+.RS
+.IP \[bu] 2
+\fBDocumentation:\fR
+.RS
+.IP \[bu] 2
+\fBAutoKey 0.95.0 through 0.95.10:\fR https://autokey.github.io/autokey/index.html
+.IP \[bu] 2
+\fBAutoKey 0.96.0 and newer:\fR https://autokey.github.io/index.html
+.RE
+.IP \[bu] 2
+\fBHome:\fR https://github.com/autokey/autokey
+.IP \[bu] 2
+\fBIssues:\fR https://github.com/autokey/autokey/issues
+.IP \[bu] 2
+\fBSocial:\fR
+.RS
+.IP \[bu] 2
+\fBDiscord:\fR https://github.com/autokey/autokey/wiki/Discord
+.IP \[bu] 2
+\fBDiscussions:\fR https://github.com/autokey/autokey/discussions
+.IP \[bu] 2
+\fBGitter:\fR https://github.com/autokey/autokey/wiki/Gitter
+.IP \[bu] 2
+\fBGoogle Groups:\fR https://github.com/autokey/autokey/wiki/Google-Groups
+.IP \[bu] 2
+\fBReddit:\fR https://github.com/autokey/autokey/wiki/Reddit
+.IP \[bu] 2
+\fBStackExchange:\fR https://github.com/autokey/autokey/wiki/StackExchange
+.RE
+.IP \[bu] 2
+\fBWiki:\fR https://github.com/autokey/autokey/wiki
+.RE

--- a/doc/man/autokey-qt.1
+++ b/doc/man/autokey-qt.1
@@ -1,9 +1,14 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
+.\" Please adjust this date whenever revising the man page:
+.TH AUTOKEY-QT "1" "June 22, 2023"
+.\"
 .\" First parameter, NAME, should be all caps.
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection.
 .\" Other parameters are allowed: see man(7), man(1).
-.TH AUTOKEY-QT "1" "April 19, 2023"
-.\" Please adjust this date whenever revising the man page.
+.\"
+.\" TeX users may be more comfortable with the \fB<whatever>\fR and
+.\" \fI<whatever>\fR escape sequences to invoke bold-face or italics,
+.\" respectively.
 .\"
 .\" Some roff macros for reference:
 .\" .nh        disable hyphenation
@@ -16,53 +21,101 @@
 .\" .sp <n>    insert n+1 empty lines
 .\" For man-page-specific macros, see man(7).
 .SH NAME
-autokey-qt \- keyboard automation utility for KDE and Qt
+\fBautokey-qt\fR \- desktop/script-automation utility for KDE
 .SH SYNOPSIS
-.B autokey-qt
-.RI [ options ]
+\fBautokey-qt\fR -[\fIc|C|h|m|v|V\fR]
 .SH DESCRIPTION
-This manual page briefly documents the \fBautokey-qt\fP command.
-.PP
-.\" TeX users may be more comfortable with the \fB<whatever>\fP and
-.\" \fI<whatever>\fP escape sequences to invoke bold-face or italics,
-.\" respectively.
-\fBautokey-qt\fP is a desktop automation utility for Linux and X11
-that's customized for use with KDE and Qt. AutoKey allows for the
-automation of virtually any task by responding to typed abbreviations
-and hotkeys. It provides a full-featured GUI to make it
-highly-accessible for novices and a scripting interface to offer the
-full flexibility and power of the Python language.
-.PP
-See the online wiki at https://github.com/autokey/autokey/wiki for more
-information.
+\fBAutoKey\fR is a set of command-line and GUI applications using GTK 
+or Qt that can be run in a variety of ways as a 
+desktop/script-automation utility for Linux and X11. \fBAutoKey\fR 
+allows for the automation of virtually any task by responding to typed 
+abbreviations and hotkeys. It provides a full-featured GUI for setting 
+up automatic text insertions or replacements and a scripting interface 
+for access to the flexibility and power of the Python language.
 .SH OPTIONS
-This program follows the usual GNU command-line syntax in which long
-options start with two dashes (`--').
-A summary of options is included below.
+This program follows the usual GNU command-line syntax with two dashes 
+used for long options. A summary of options is included below.
 .TP
 .B \-c, \-\-configure
 Open the AutoKey main window.
 .TP
-.B \-\-cutelog-integration
-Connect to a locally-running \fBcutelog\fP instance with default
-settings to display the full program log.
-.br
-See the \fBcutelog\fP GitHub page at https://github.com/busimus/cutelog
-for more information.
+.B \-C, \-\-cutelog
+Connect to a local default \fBcutelog\fR instance to display the full 
+program log.
 .TP
 .B \-h, \-\-help
 Show a summary of all options.
 .TP
-.B \-l, \-\-verbose
-Enable verbose (debug) logging.
-.TP
 .B \-m, \-\-mouse
-Enable verbose (debug) logging that includes mouse-button events.
+Enable verbose logging that includes mouse-button events.
+.TP
+.B \-v, \-\-verbose, \-l
+Enable verbose logging (\fB-l\fR is deprecated).
 .TP
 .B \-V, \-\-version
-Print the current AutoKey version to standard output and then exit.
+Print the current AutoKey version to standard output.
 .SH AUTHOR
-AutoKey was written by Chris Dekter and was loosely based on a script by
-Sam Peterson.
-.PP
-This manual page was written by Chris Dekter <cdekter@gmail.com>.
+AutoKey was written by Chris Dekter <cdekter@gmail.com> and was loosely 
+based on a script by Sam Peterson.
+.SH SEE ALSO
+.TP
+\fBautokey-gtk\fR(1), \fBautokey-run\fR(1), \fBpython\fR(1), \fBwmctrl\fR(1), \fBxautomation\fR(7), \fBxdotool\fR(1), \fBxmodmap\fR(1)
+.TP
+\fBRelated software:\fR
+.RS
+.IP \[bu] 2
+\fBcutelog:\fR https://github.com/busimus/cutelog
+.IP \[bu] 2
+\fBKDialog:\fR https://github.com/KDE/kdialog
+.IP \[bu] 2
+\fBRegular expression syntax:\fR https://docs.python.org/3/library/re.html
+.IP \[bu] 2
+\fBRegular expression tutorial:\fR https://docs.python.org/3/howto/regex.html
+.IP \[bu] 2
+\fBXKB:\fR https://www.x.org/releases/current/doc/xorg-docs/input/XKB-Config.html
+.RE
+.TP
+\fBSimilar software in other operating systems:\fR
+.RS
+.IP \[bu] 2
+\fBAutoHotKey\fR is a free and open-source tool available for Micosoft
+Windows users.
+.IP \[bu] 2
+\fBAutomator\fR is a default Apple tool.
+.IP \[bu] 2
+\fBText Replacement\fR is a default Apple tool.
+.RE
+.TP
+\fBAutoKey web pages:\fR
+.RS
+.IP \[bu] 2
+\fBDocumentation:\fR
+.RS
+.IP \[bu] 2
+\fBAutoKey 0.95.0 through 0.95.10:\fR https://autokey.github.io/autokey/index.html
+.IP \[bu] 2
+\fBAutoKey 0.96.0 and newer:\fR https://autokey.github.io/index.html
+.RE
+.IP \[bu] 2
+\fBHome:\fR https://github.com/autokey/autokey
+.IP \[bu] 2
+\fBIssues:\fR https://github.com/autokey/autokey/issues
+.IP \[bu] 2
+\fBSocial:\fR
+.RS
+.IP \[bu] 2
+\fBDiscord:\fR https://github.com/autokey/autokey/wiki/Discord
+.IP \[bu] 2
+\fBDiscussions:\fR https://github.com/autokey/autokey/discussions
+.IP \[bu] 2
+\fBGitter:\fR https://github.com/autokey/autokey/wiki/Gitter
+.IP \[bu] 2
+\fBGoogle Groups:\fR https://github.com/autokey/autokey/wiki/Google-Groups
+.IP \[bu] 2
+\fBReddit:\fR https://github.com/autokey/autokey/wiki/Reddit
+.IP \[bu] 2
+\fBStackExchange:\fR https://github.com/autokey/autokey/wiki/StackExchange
+.RE
+.IP \[bu] 2
+\fBWiki:\fR https://github.com/autokey/autokey/wiki
+.RE

--- a/doc/man/autokey-qt.1
+++ b/doc/man/autokey-qt.1
@@ -1,6 +1,6 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
 .\" Please adjust this date whenever revising the man page:
-.TH AUTOKEY-QT "1" "June 22, 2023"
+.TH AUTOKEY-QT "1" "June 25, 2023"
 .\"
 .\" First parameter, NAME, should be all caps.
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection.
@@ -20,10 +20,14 @@
 .\" .br        insert line break
 .\" .sp <n>    insert n+1 empty lines
 .\" For man-page-specific macros, see man(7).
+
 .SH NAME
-\fBautokey-qt\fR \- desktop/script-automation utility for KDE
+\fBautokey-gtk\fR  \- desktop/script-automation utility with a 
+Qt-based graphical interface
+
 .SH SYNOPSIS
 \fBautokey-qt\fR -[\fIc|C|h|m|v|V\fR]
+
 .SH DESCRIPTION
 \fBAutoKey\fR is a set of command-line and GUI applications using GTK 
 or Qt that can be run in a variety of ways as a 
@@ -32,6 +36,7 @@ allows for the automation of virtually any task by responding to typed
 abbreviations and hotkeys. It provides a full-featured GUI for setting 
 up automatic text insertions or replacements and a scripting interface 
 for access to the flexibility and power of the Python language.
+
 .SH OPTIONS
 This program follows the usual GNU command-line syntax with two dashes 
 used for long options. A summary of options is included below.
@@ -54,9 +59,11 @@ Enable verbose logging (\fB-l\fR is deprecated).
 .TP
 .B \-V, \-\-version
 Print the current AutoKey version to standard output.
+
 .SH AUTHOR
 AutoKey was written by Chris Dekter <cdekter@gmail.com> and was loosely 
 based on a script by Sam Peterson.
+
 .SH SEE ALSO
 .TP
 \fBautokey-gtk\fR(1), \fBautokey-run\fR(1), \fBpython\fR(1), \fBwmctrl\fR(1), \fBxautomation\fR(7), \fBxdotool\fR(1), \fBxmodmap\fR(1)


### PR DESCRIPTION
* Move the date to the top of the document.
* Update the date.
* Move TeX instructions up with the rest of the instructions.
* Add the **SEE ALSO** section.
* In the **NAME** section:
  * Update the text.
* In the **SYNOPSIS** section:
  * Reformat the section.
  * Add the options to the example command.
* In the **DESCRIPTION** section:
  * Reformat the section.
  * Remove unnecessary information.
  * Update the text.
* In the **OPTIONS** section:
  * Reformat the section.
  * Sort the section alphabetically.
  * Update the section's introductory text.
  * Reformat the **cutelog** option.
  * Add the short **cutelog** command-line switch.
  * Rename the long **cutelog** command-line switch.
  * Update the **cutelog** option's description.
  * Update the **mouse** option's description.
  * Add the short **verbose** command-line switch.
  * Deprecate the short **verbose** -l command-line switch.
  * Update the**verbose** option's description.
  * Update the **version** option's description.
* In the **AUTHOR** section:
  * Remove man-page-authorship attribution.
  * Update the text.
* In the **SEE ALSO** section:
  * Move the **cutelog** link from the **OPTIONS** section to the **SEE ALSO** section.
  * Move the wiki link from the **DESCRIPTION** section to the **SEE ALSO** section.
  * Add man-page links.
  * Add other links.
