### PR TITLE
Update lib.scripting.Keyboard-class.html

### DIFF
--- a/doc/scripting/lib.scripting.Keyboard-class.html
+++ b/doc/scripting/lib.scripting.Keyboard-class.html
@@ -270,7 +270,7 @@
   <dl class="fields">
     <dt>Parameters:</dt>
     <dd><ul class="nomargin-top">
-        <li><strong class="pname"><code>key</code></strong> - they key to be sent (e.g. &quot;s&quot; or 
+        <li><strong class="pname"><code>key</code></strong> - the key to be sent (e.g. &quot;s&quot; or 
           &quot;&lt;enter&gt;&quot;)</li>
         <li><strong class="pname"><code>repeat</code></strong> - number of times to repeat the key event</li>
     </ul></dd>
@@ -299,7 +299,7 @@
   <dl class="fields">
     <dt>Parameters:</dt>
     <dd><ul class="nomargin-top">
-        <li><strong class="pname"><code>key</code></strong> - they key to be pressed (e.g. &quot;s&quot; or 
+        <li><strong class="pname"><code>key</code></strong> - the key to be pressed (e.g. &quot;s&quot; or 
           &quot;&lt;enter&gt;&quot;)</li>
     </ul></dd>
   </dl>
@@ -327,7 +327,7 @@
   <dl class="fields">
     <dt>Parameters:</dt>
     <dd><ul class="nomargin-top">
-        <li><strong class="pname"><code>key</code></strong> - they key to be released (e.g. &quot;s&quot; or 
+        <li><strong class="pname"><code>key</code></strong> - the key to be released (e.g. &quot;s&quot; or 
           &quot;&lt;enter&gt;&quot;)</li>
     </ul></dd>
   </dl>
@@ -356,7 +356,7 @@
   <dl class="fields">
     <dt>Parameters:</dt>
     <dd><ul class="nomargin-top">
-        <li><strong class="pname"><code>key</code></strong> - they key to be sent (e.g. &quot;s&quot; or 
+        <li><strong class="pname"><code>key</code></strong> - the key to be sent (e.g. &quot;s&quot; or 
           &quot;&lt;enter&gt;&quot;)</li>
         <li><strong class="pname"><code>repeat</code></strong> - number of times to repeat the key event</li>
     </ul></dd>
@@ -388,7 +388,7 @@
   <dl class="fields">
     <dt>Parameters:</dt>
     <dd><ul class="nomargin-top">
-        <li><strong class="pname"><code>key</code></strong> - they key to wait for</li>
+        <li><strong class="pname"><code>key</code></strong> - the key to wait for</li>
         <li><strong class="pname"><code>modifiers</code></strong> - list of modifiers that should be pressed with the key</li>
         <li><strong class="pname"><code>timeOut</code></strong> - maximum time, in seconds, to wait for the keypress to occur</li>
     </ul></dd>


### PR DESCRIPTION
Fix typo: Replace all occurrences of "**they key**" with "**the key**" in  [doc/scripting/lib.scripting.Keyboard-class.html](https://github.com/autokey/autokey/blob/master/doc/scripting/lib.scripting.Keyboard-class.html).