### PR TITLE
Update CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -108,7 +108,8 @@ Other changes
 - Update formatting and wording in the AutoKey GTK and Qt clipboard API documentation.
 - Remove one reference to X in the AutoKey GTK clipboard API documentation.
 - Remove one reference to mouse in the AutoKey Qt clipboard API documentation.
-- AutoKey now has a working test environment again. `pytest` based unit-tests can be launched from the source checkout using `python3 setup.py test`
+- AutoKey now has a working test environment again. `pytest` based unit-tests can be launched from the source checkout using `python3 setup.py test
+- Fix typo: Replace all occurrences of "they key" with "the key" in the AutoKey documentation.
 
 **New Dependencies (test-time only)**
 


### PR DESCRIPTION
Note the typo fix (replacing "**they key**" with "**the key**") in these three files:
* [doc/scripting/lib.scripting-pysrc.html](https://github.com/autokey/autokey/blob/master/doc/scripting/lib.scripting-pysrc.html)
* [doc/scripting/lib.scripting.Keyboard-class.html](https://github.com/autokey/autokey/blob/master/doc/scripting/lib.scripting.Keyboard-class.html)
* [lib/autokey/scripting/keyboard.py](https://github.com/autokey/autokey/blob/master/lib/autokey/scripting/keyboard.py).
