### PR TITLE
Bump AutoKey version in autokey.spec file to satisfy #227

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Important misc changes
 - Update the GTK and Qt man pages.
 - Update date, formatting, and NAME section in the GTK and Qt man pages.
 - Fix typo: Replace all occurrences of "they key" with "the key" in the AutoKey documentation.
+- Bump the AutoKey version to 0.96.1 in the **autokey.spec** file to satisfy part of issue #227.
 
 Features
 ---------

--- a/autokey.spec
+++ b/autokey.spec
@@ -8,7 +8,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name:           autokey
-Version:        0.94.1
+Version:        0.96.1
 Release:        1
 License:        GPLv3
 Summary:        Desktop automation utility


### PR DESCRIPTION
Bump the AutoKey version to 0.96.1 in the autokey.spec file to satisfy part of issue #227.