### PR TITLE
Fixed error when dialog choice is cancelled

### DIFF
--- a/lib/autokey/scripting/dialog_qt.py
+++ b/lib/autokey/scripting/dialog_qt.py
@@ -139,7 +139,10 @@ class QtDialog:
             optionNum += 1
 
         return_code, result = self._run_kdialog(title, ["--radiolist", message] + choices, kwargs)
-        choice = options[int(result)]
+        if (return_code == 0):
+            choice = options[int(result)]
+        else:
+            choice = None
 
         return DialogData(return_code, choice)
 


### PR DESCRIPTION
Clicking cancel on the dialog menu would cause 2 things. 
1- It would make the return_code variable nonzero
2- It would make the result a non integer

So cancelling the choice would cause an error on the script. This fix would check the return code and return None on any nonzero return code.