### PR TITLE
Remove unnecessary white-space from the config.yml file.

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,1 @@
-	blank_issues_enabled: false 
- 
+blank_issues_enabled: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -114,6 +114,7 @@ Other changes
 - Fix typo: Replace all occurrences of "they key" with "the key" in the AutoKey documentation.
 - Rename the bug.yaml file to bug.yml.
 - Add the `config.yml` file to the `/.github/ISSUE_TEMPLATE` directory to prevent blank issues from being offered and created. Fixes `#897`_
+- Remove unnecessary white-space from the `config.yml` file.
 
 .. _`#897`: https://github.com/autokey/autokey/issues/897
 


### PR DESCRIPTION
Remove the unnecessary white-space from the [config.yml](https://github.com/autokey/autokey/blob/master/.github/ISSUE_TEMPLATE/config.yml) file that had gotten there from copying and pasting.
