### PR TITLE
Added miliseconds to recent script errors dialogue.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,7 +79,7 @@ Other
 - Link to script `.py` and `.json` above editor.
 - Add appropriate keywords to `.desktop` files for both UIs.
 - Build debs and update pypi on new releases
-- Add miliseconds to `show_recent_script_errors_dialog`
+- add `show_recent_script_errors_dialog` to display errors with millisecond precision.
 
 Bug fixes
 ---------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Next Version
+============================
+Other
++++++
+- Add `show_recent_script_errors_dialog` to display errors with millisecond precision.
+
 Version 0.96.0
 ============================
 
@@ -79,7 +85,6 @@ Other
 - Link to script `.py` and `.json` above editor.
 - Add appropriate keywords to `.desktop` files for both UIs.
 - Build debs and update pypi on new releases
-- add `show_recent_script_errors_dialog` to display errors with millisecond precision.
 
 Bug fixes
 ---------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -79,6 +79,7 @@ Other
 - Link to script `.py` and `.json` above editor.
 - Add appropriate keywords to `.desktop` files for both UIs.
 - Build debs and update pypi on new releases
+- Add miliseconds to `show_recent_script_errors_dialog`
 
 Bug fixes
 ---------

--- a/lib/autokey/qtui/dialogs/show_recent_script_errors.py
+++ b/lib/autokey/qtui/dialogs/show_recent_script_errors.py
@@ -115,7 +115,7 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
         Switch to the next error in the error list.
         The connection from the Next button to this slot function is defined in the .ui file.
         """
-        # Out of bounds handling is not needed, as the Next button gets disables when the last error is reached.
+        # Out of bounds handling is not needed, as the Next button gets disabled when the last error is reached.
         # See has_next_error Signal.
         self.currently_viewed_error_index += 1
         self._emit_has_next_error()
@@ -127,7 +127,7 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
         Switch to the previous error in the error list.
         The connection from the Previous button to this slot function is defined in the .ui file.
         """
-        # Out of bounds handling is not needed, as the Previous button gets disables when the first error is reached.
+        # Out of bounds handling is not needed, as the Previous button gets disabled when the first error is reached.
         # See has_previous_error Signal.
         self.currently_viewed_error_index -= 1
         self._emit_has_previous_error()

--- a/lib/autokey/qtui/dialogs/show_recent_script_errors.py
+++ b/lib/autokey/qtui/dialogs/show_recent_script_errors.py
@@ -32,8 +32,6 @@ class ShowRecentScriptErrorsDialog(*ui_common.inherits_from_ui_file_with_name("s
     with errors, which can be viewed and cleared using this dialogue window.
 
     """
-    # TODO: When the minimal python version is raised to >= 3.6, add millisecond display to both the script start
-    # timestamp and the error timestamp.
 
     # When switching errors, emit a boolean indicating if previous errors are available. The Previous button reacts on
     # this and enables/disables itself based on the boolean value. The connection is defined in the .ui file.

--- a/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
+++ b/lib/autokey/qtui/resources/ui/show_recent_script_errors_dialog.ui
@@ -46,7 +46,7 @@
       <enum>QAbstractSpinBox::NoButtons</enum>
      </property>
      <property name="displayFormat">
-      <string>HH:mm:ss</string>
+      <string>HH:mm:ss.zzz</string>
      </property>
     </widget>
    </item>
@@ -178,7 +178,7 @@
       <bool>false</bool>
      </property>
      <property name="placeholderText">
-      <string notr="true">The failing script’s stack trace is shown here.</string>
+      <string notr="true">The failing script's stack trace is shown here.</string>
      </property>
      <property name="openLinks">
       <bool>false</bool>
@@ -200,7 +200,7 @@
       <enum>QAbstractSpinBox::NoButtons</enum>
      </property>
      <property name="displayFormat">
-      <string>HH:mm:ss</string>
+      <string>HH:mm:ss.zzz</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The script error dialogue will now display milliseconds as per [issue #792](https://github.com/autokey/autokey/issues/792)

Before:
![image](https://github.com/user-attachments/assets/0528cb73-6d51-422e-8278-5ad5c45888cd)

After:
![image](https://github.com/user-attachments/assets/6ff8b469-68a1-4b49-8834-0aa34bb6df34)

Ran the tests from the master branch unfortunately. Although the changes are so small that this should not be the issue.

Thank you for the opportunity to contribute.