### PR TITLE
Bump action versions in workflow files. Fixes #963 and #965.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,16 +18,16 @@ jobs:
       matrix:
         python-version: [3.10.1]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -53,7 +53,7 @@ jobs:
         mv ../*.deb debs
 
     - name: Upload built debs as artifacts
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v4
       with:
         name: debs
         path: debs
@@ -66,14 +66,14 @@ jobs:
       matrix:
         python-version: [3.10.1]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -99,7 +99,7 @@ jobs:
         --outdir dist/
 
     - name: Upload built dist as artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/
@@ -113,7 +113,7 @@ jobs:
         python-version: [3.10.1]
     needs: [build_pypi_wheel, build_deb]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Fetch all history so that we get tags.
         fetch-depth: 0
@@ -128,12 +128,12 @@ jobs:
         check-name: 'pytest (3.10.1)'
 
     - name: Download built dist as artifact
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist/
     - name: Download built debs as artifacts
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v4
       with:
         name: debs
         path: ../debs

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: doc/scripting
   deploy:
@@ -29,5 +29,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
           

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,14 +24,14 @@ jobs:
         python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -86,16 +86,16 @@ jobs:
         python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -117,7 +117,7 @@ jobs:
         run: tox -e clean,coverage,report
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
@@ -128,7 +128,7 @@ jobs:
         run: tar -cvzf test_coverage_report-${{ matrix.python-version }}.tar.gz test_coverage_report_html/
 
       - name: Upload test coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_coverage_report-${{ matrix.python-version }}.tar.gz
           path: test_coverage_report-${{ matrix.python-version }}.tar.gz
@@ -145,9 +145,9 @@ jobs:
         python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,13 @@ Changelog
 
 Next Version
 ============================
+
+Important misc changes
+----------------------
+- Bump action versions in pages.yml to satisfy part of issue #963.
+- Bump action versions in build.yml to satisfy part of issue #963.
+- Bump action versions in python-test.yml to satisfy part of issue #963.
+
 Other
 +++++
 - Add `show_recent_script_errors_dialog` to display errors with millisecond precision.


### PR DESCRIPTION
* Bump action versions in the `pages.yml` file.
* Bump action versions in the `build.yml` file.
* Bump action versions in the `python-test.yml` file.
