### PR TITLE
Bump Python versions in workflow files to satisfy issue #964.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10.1]
+        python-version: [3.11.10]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10.1]
+        python-version: [3.11.10]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10.1]
+        python-version: [3.11.10]
     needs: [build_pypi_wheel, build_deb]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,8 @@ Important misc changes
 - Bump action versions in pages.yml to satisfy part of issue #963.
 - Bump action versions in build.yml to satisfy part of issue #963.
 - Bump action versions in python-test.yml to satisfy part of issue #963.
+- Bump Python version in build.yml to satisfy part of issue #964.
+- Bump Python versions in python-test.yml to satisfy part of issue #964.
 
 Other
 +++++


### PR DESCRIPTION
* Bump Python version in the `build.yml` file to **3.11**.
* Bump Python version range in the `python-test.yml` file to **3.9** through **3.11**.
