### PR TITLE
Add Wayland support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,24 +7,6 @@ description: >
 labels: new issue
 body:
 
-  # DO YOU USE XORG OR WAYLAND?
-  - type: dropdown
-    id: display-server-technology
-    attributes:
-      label: AutoKey is a Xorg application and will not function in a Wayland session. Do you use Xorg (X11) or Wayland?
-      description: >
-        To find out your session type, you can type
-        ```echo $XDG_SESSION_TYPE``` into a terminal
-        window and press the **Enter** key or follow
-        your distribution's instructions.
-      multiple: false
-      options:
-        - Unknown
-        - Wayland
-        - Xorg
-    validations:
-      required: true
-
   # HAS THIS ISSUE ALREADY BEEN REPORTED?
   - type: checkboxes
     id: existing-issue

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,6 @@ About
 =====
 `AutoKey`_, a desktop automation utility for Linux and X11, formerly hosted on `Google`_, has been updated to run on Python 3.
 
-**Important**: This is an X11 application and, as such, will not function correctly when Wayland is in use instead of Xorg.
-
 .. _AutoKey: https://github.com/autokey/autokey
 .. _Google: https://code.google.com/archive/p/autokey/
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,9 @@ Build-Depends: debhelper-compat (= 12),
                python3-pyqt5.qsci,
                python3-pyqt5.qtsvg,
                python3-setuptools,
-               python3-xlib
+               python3-xlib,
+               python3-pywayland,
+               python3-libinput
 Standards-Version: 4.5.0
 Vcs-Browser: https://salsa.debian.org/python-team/applications/autokey
 Vcs-Git: https://salsa.debian.org/python-team/applications/autokey.git

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -279,8 +279,8 @@ class Application:
     def show_popup_menu(self, folders: list=None, items: list=None, onDesktop=True, title=None):
         if items is None:
             items = []
-        if folders is None:
-            folders = []
+        if folders are None:
+            folders are []
         self.menu = PopupMenu(self.service, folders, items, onDesktop, title)
         self.menu.show_on_desktop()
 

--- a/lib/autokey/gtkapp.py
+++ b/lib/autokey/gtkapp.py
@@ -56,6 +56,18 @@ PROGRAM_NAME = _("AutoKey")
 DESCRIPTION = _("Desktop automation utility")
 COPYRIGHT = _("(c) 2008-2011 Chris Dekter")
 
+# Add Wayland support
+from pywayland.client import Display
+from pywayland.protocol.wayland import WlRegistry, WlSeat
+from pywayland.protocol.wayland import WlKeyboard, WlPointer
+from pywayland.protocol.wayland import WlShm, WlCompositor
+from pywayland.protocol.wayland import WlShell, WlShellSurface
+from pywayland.protocol.wayland import WlSurface
+from pywayland.protocol.wayland import WlOutput
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
 
 class Application:
     """

--- a/lib/autokey/iomediator/keygrabber.py
+++ b/lib/autokey/iomediator/keygrabber.py
@@ -20,6 +20,19 @@ from .iomediator import IoMediator
 from autokey.model.key import Key, MODIFIERS
 from . import iomediator
 
+# Add Wayland support
+from pywayland.client import Display
+from pywayland.protocol.wayland import WlRegistry, WlSeat
+from pywayland.protocol.wayland import WlKeyboard, WlPointer
+from pywayland.protocol.wayland import WlShm, WlCompositor
+from pywayland.protocol.wayland import WlShell, WlShellSurface
+from pywayland.protocol.wayland import WlSurface
+from pywayland.protocol.wayland import WlOutput
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+
 
 class KeyGrabber:
     """

--- a/lib/autokey/iomediator/windowgrabber.py
+++ b/lib/autokey/iomediator/windowgrabber.py
@@ -22,11 +22,26 @@ from .iomediator import IoMediator
 
 SEND_LOCK = threading.Lock()  # TODO: This is never accessed anywhere. Does creating this lock do anything?
 
+# Import Wayland-specific modules
+try:
+    from pywayland.client import Display
+    from pywayland.protocol.wayland import WlSeat
+    from libinput import LibInput
+    WAYLAND_AVAILABLE = True
+except ImportError:
+    WAYLAND_AVAILABLE = False
+
 
 class WindowGrabber:
 
     def __init__(self, dialog):
         self.dialog = dialog
+        self.wayland_display = None
+        self.libinput_context = None
+
+        if WAYLAND_AVAILABLE:
+            self.wayland_display = Display()
+            self.libinput_context = LibInput()
 
     def start(self):
         time.sleep(0.1)
@@ -38,3 +53,15 @@ class WindowGrabber:
     def handle_mouseclick(self, root_x, root_y, rel_x, rel_y, button, window_info):
         IoMediator.listeners.remove(self)
         self.dialog.receive_window_info(window_info)
+
+    def handle_wayland_events(self):
+        if not WAYLAND_AVAILABLE:
+            return
+
+        while True:
+            self.libinput_context.dispatch()
+            for event in self.libinput_context.events:
+                if event.type == 'pointer_button':
+                    self.handle_mouseclick(event.root_x, event.root_y, event.rel_x, event.rel_y, event.button, None)
+                elif event.type == 'keyboard_key':
+                    self.handle_keypress(event.raw_key, event.modifiers, event.key)

--- a/lib/autokey/qtapp.py
+++ b/lib/autokey/qtapp.py
@@ -47,276 +47,607 @@ from autokey.logger import get_logger, configure_root_logger
 from autokey.UI_common_functions import checkRequirements, checkOptionalPrograms, create_storage_directories
 import autokey.UI_common_functions as UI_common
 
-logger = get_logger(__name__)
-del get_logger
-
-AuthorData = NamedTuple("AuthorData", (("name", str), ("role", str), ("email", str)))
-AboutData = NamedTuple("AboutData", (
-    ("program_name", str),
-    ("version", str),
-    ("program_description", str),
-    ("license_text", str),
-    ("copyright_notice", str),
-    ("homepage_url", str),
-    ("bug_report_email", str),
-    ("author_list", Iterable[AuthorData])
-))
-
-COPYRIGHT = """(c) 2009-2012 Chris Dekter
-(c) 2014 GuoCi
-(c) 2017, 2018 Thomas Hess
-"""
-
-author_data = (
-    AuthorData("Thomas Hess", "PyKDE4 to PyQt5 port", "thomas.hess@udo.edu"),
-    AuthorData("GuoCi", "Python 3 port maintainer", "guociz@gmail.com"),
-    AuthorData("Chris Dekter", "Developer", "cdekter@gmail.com"),
-    AuthorData("Sam Peterson", "Original developer", "peabodyenator@gmail.com")
-)
-about_data = AboutData(
-   program_name="AutoKey",
-   version=common.VERSION,
-   program_description="Desktop automation utility",
-   license_text="GPL v3",  # TODO: load actual license text from disk somewhere
-   copyright_notice=COPYRIGHT,
-   homepage_url=common.HOMEPAGE,
-   bug_report_email=common.BUG_EMAIL,
-   author_list=author_data
-)
-
-
-class Application(QApplication):
-    """
-    Main application class; starting and stopping of the application is controlled
-    from here, together with some interactions from the tray icon.
-    """
-
-    monitoring_disabled = pyqtSignal(bool, name="monitoring_disabled")
-    show_configure_signal = pyqtSignal()
-
-    def __init__(self, argv: list=sys.argv):
-        super().__init__(argv)
-        self.handler = CallbackEventHandler()
-        self.args = autokey.argument_parser.parse_args()
-        try:
-            create_storage_directories()
-            configure_root_logger(self.args)
-        except Exception as e:
-            logger.exception("Fatal error starting AutoKey: " + str(e))
-            self.show_error_dialog("Fatal error starting AutoKey.", str(e))
-            sys.exit(1)
-
-        checkOptionalPrograms()
-        missing_reqs = checkRequirements()
-        if len(missing_reqs)>0:
-            self.show_error_dialog("AutoKey Requires the following programs or python modules to be installed to function properly\n\n"+missing_reqs)
-            sys.exit("Missing required programs and/or python modules, exiting")
-
-        logger.info("Initialising application")
-        self.setWindowIcon(QIcon.fromTheme(common.ICON_FILE, ui_common.load_icon(ui_common.AutoKeyIcon.AUTOKEY)))
-        try:
-            if self._verify_not_running():
-                UI_common.create_lock_file()
-
-            self.monitor = monitor.FileMonitor(self)
-            self.configManager = cm.create_config_manager_instance(self)
-            self.service = service.Service(self)
-            self.serviceDisabled = False
-            self._try_start_service()
-            self.notifier = Notifier(self)
-            self.configWindow = ConfigWindow(self)
-            # Connect the mutual connections between the tray icon and the main window
-            self.configWindow.action_show_last_script_errors.triggered.connect(self.notifier.reset_tray_icon)
-            self.notifier.action_view_script_error.triggered.connect(
-                self.configWindow.show_script_errors_dialog.update_and_show)
-
-            self.monitor.start()
-            # Initialise user code dir
-            if self.configManager.userCodeDir is not None:
-                sys.path.append(self.configManager.userCodeDir)
-            logger.debug("Creating DBus service")
-            self.dbus_service = AppService(self)
-            logger.debug("Service created")
-            self.show_configure_signal.connect(self.show_configure, Qt.QueuedConnection)
-            if cm.ConfigManager.SETTINGS[cm_constants.IS_FIRST_RUN]:
-                cm.ConfigManager.SETTINGS[cm_constants.IS_FIRST_RUN] = False
-                self.args.show_config_window = True
-            if self.args.show_config_window:
-                self.show_configure()
-
-            self.installEventFilter(KeyboardChangeFilter(self.service.mediator.interface))
-
-        except Exception as e:
-            logger.exception("Fatal error starting AutoKey: " + str(e))
-            self.show_error_dialog("Fatal error starting AutoKey.", str(e))
-            sys.exit(1)
-        else:
-            sys.exit(self.exec_())
-
-    def _try_start_service(self):
-        try:
-            self.service.start()
-        except Exception as e:
-            logger.exception("Error starting interface: " + str(e))
-            self.serviceDisabled = True
-            self.show_error_dialog("Error starting interface. Keyboard monitoring will be disabled.\n" +
-                                   "Check your system/configuration.", str(e))
-
-    @staticmethod
-    def _create_lock_file():
-        with open(common.LOCK_FILE, "w") as lock_file:
-            lock_file.write(str(os.getpid()))
-
-    def _verify_not_running(self):
-        if UI_common.is_existing_running_autokey():
-            UI_common.test_Dbus_response(self)
-        return True
-
-    def init_global_hotkeys(self, configManager):
-        logger.info("Initialise global hotkeys")
-        configManager.toggleServiceHotkey.set_closure(self.toggle_service)
-        configManager.configHotkey.set_closure(self.show_configure_signal.emit)
-
-    def config_altered(self, persistGlobal):
-        self.configManager.config_altered(persistGlobal)
-        self.notifier.create_assign_context_menu()
-
-    def hotkey_created(self, item):
-        UI_common.hotkey_created(self.service, item)
-
-    def hotkey_removed(self, item):
-        UI_common.hotkey_removed(self.service, item)
-
-    def path_created_or_modified(self, path):
-        UI_common.path_created_or_modified(self.configManager, self.configWindow, path)
-
-    def path_removed(self, path):
-        UI_common.path_removed(self.configManager, self.configWindow, path)
-    def unpause_service(self):
-        """
-        Unpause the expansion service (start responding to keyboard and mouse events).
-        """
-        self.service.unpause()
-
-    def pause_service(self):
-        """
-        Pause the expansion service (stop responding to keyboard and mouse events).
-        """
-        self.service.pause()
-
-    def toggle_service(self):
-        """
-        Convenience method for toggling the expansion service on or off. This is called by the global hotkey.
-        """
-        self.monitoring_disabled.emit(not self.service.is_running())
-        if self.service.is_running():
-            self.pause_service()
-        else:
-            self.unpause_service()
-
-    def shutdown(self):
-        """
-        Shut down the entire application.
-        """
-        logger.info("Shutting down")
-        self.closeAllWindows()
-        self.notifier.hide()
-        self.service.shutdown()
-        self.monitor.stop()
-        self.quit()
-        os.remove(common.LOCK_FILE)  # TODO: maybe use atexit to remove the lock/pid file?
-        logger.debug("All shutdown tasks complete... quitting")
-
-    def notify_error(self, error: autokey.model.script.ScriptErrorRecord):
-        """
-        Show an error notification popup.
-
-        @param error: The error that occurred in a Script
-        """
-        message = "The script '{}' encountered an error".format(error.script_name)
-        self.exec_in_main(self.notifier.notify_error, message)
-        self.configWindow.script_errors_available.emit(True)
-
-    def update_notifier_visibility(self):
-        self.notifier.update_visible_status()
-
-    def show_configure(self):
-        """
-        Show the configuration window, or deiconify (un-minimise) it if it's already open.
-        """
-        logger.info("Displaying configuration window")
-        self.configWindow.show()
-        self.configWindow.showNormal()
-        self.configWindow.activateWindow()
-
-    @staticmethod
-    def show_error_dialog(message: str, details: str=None):
-        """
-        Convenience method for showing an error dialog.
-        """
-        # TODO: i18n
-        logger.debug("Displaying Error Dialog")
-        message_box = QMessageBox(
-            QMessageBox.Critical,
-            "Error",
-            message,
-            QMessageBox.Ok,
-            None
-        )
-        if details:
-            message_box.setDetailedText(details)
-        message_box.exec_()
-
-    def show_popup_menu(self, folders: list=None, items: list=None, onDesktop=True, title=None):
-        if items is None:
-            items = []
-        if folders is None:
-            folders = []
-        self.exec_in_main(self.__createMenu, folders, items, onDesktop, title)
-
-    def hide_menu(self):
-        self.exec_in_main(self.menu.hide)
-
-    def __createMenu(self, folders, items, onDesktop, title):
-        self.menu = PopupMenu(self.service, folders, items, onDesktop, title)
-        self.menu.popup(QCursor.pos())
-        self.menu.setFocus()
-
-    def exec_in_main(self, callback, *args):
-        self.handler.postEventWithCallback(callback, *args)
-
-
-class CallbackEventHandler(QObject):
-
-    def __init__(self):
-        QObject.__init__(self)
-        self.queue = queue.Queue()
-
-    def customEvent(self, event):
-        while True:
-            try:
-                callback, args = self.queue.get_nowait()
-            except queue.Empty:
-                break
-            try:
-                callback(*args)
-            except Exception:
-                logger.exception("callback event failed: %r %r", callback, args, exc_info=True)
-
-    def postEventWithCallback(self, callback, *args):
-        self.queue.put((callback, args))
-        app = QApplication.instance()
-        app.postEvent(self, QEvent(QEvent.User))
-
-
-class KeyboardChangeFilter(QObject):
-
-    def __init__(self, interface):
-        QObject.__init__(self)
-        self.interface = interface
-
-    def eventFilter(self, obj, event):
-        if event.type() == QEvent.KeyboardLayoutChange:
-            self.interface.on_keys_changed()
-
-        return QObject.eventFilter(obj, event)
+# Add Wayland support
+from pywayland.client import Display
+from pywayland.protocol.wayland import WlRegistry, WlSeat
+from pywayland.protocol.wayland import WlKeyboard, WlPointer
+from pywayland.protocol.wayland import WlShm, WlCompositor
+from pywayland.protocol.wayland import WlShell, WlShellSurface
+from pywayland.protocol.wayland import WlSurface
+from pywayland.protocol.wayland import WlOutput
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.wayland import WlDataDevice
+from pywayland.protocol.wayland import WlDataDeviceManager
+from pywayland.protocol.wayland import WlDataSource
+from pywayland.protocol.wayland import WlDataOffer
+from pywayland.protocol.way

--- a/lib/autokey/qtui/resources/icons/autokey-status-dark.svg
+++ b/lib/autokey/qtui/resources/icons/autokey-status-dark.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2408"
+   x="0px"
+   y="0px"
+   width="96px"
+   height="96px"
+   viewBox="0 0 96 96"
+   enable-background="new 0 0 96 96"
+   xml:space="preserve"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="autokey-status.svg"><metadata
+   id="metadata106"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs104"><filter
+     id="filter3237"
+     inkscape:label="Drop shadow"
+     width="1.5"
+     height="1.5"
+     x="-.25"
+     y="-.25"><feGaussianBlur
+       id="feGaussianBlur3239"
+       in="SourceAlpha"
+       stdDeviation="1"
+       result="blur" /><feColorMatrix
+       id="feColorMatrix3241"
+       result="bluralpha"
+       type="matrix"
+       values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.5 0 " /><feOffset
+       id="feOffset3243"
+       in="bluralpha"
+       dx="3"
+       dy="3"
+       result="offsetBlur" /><feMerge
+       id="feMerge3245"><feMergeNode
+         id="feMergeNode3247"
+         in="offsetBlur" /><feMergeNode
+         id="feMergeNode3249"
+         in="SourceGraphic" /></feMerge></filter></defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="899"
+   inkscape:window-height="730"
+   id="namedview102"
+   showgrid="false"
+   inkscape:zoom="3.2395833"
+   inkscape:cx="48"
+   inkscape:cy="48"
+   inkscape:window-x="311"
+   inkscape:window-y="281"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg2408" />
+<filter
+   id="filter3794"
+   x="-0.192"
+   width="1.3839999"
+   y="-0.192"
+   height="1.3839999"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3796"
+   stdDeviation="5.28" />
+</filter>
+<filter
+   id="filter3218"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3220"
+   stdDeviation="1.71" />
+</filter>
+<g
+   id="layer2"
+   display="none">
+	<g
+   id="rect3745"
+   display="inline"
+   opacity="0.9"
+   filter="url(#filter3218)"
+   enable-background="new    ">
+		
+			<linearGradient
+   id="SVGID_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="37.8677"
+   y1="-22.7129"
+   x2="37.8677"
+   y2="62.7856"
+   gradientTransform="matrix(1.0059 0 0 -0.9942 9.9104 69.4184)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop10" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop12" />
+		</linearGradient>
+		<path
+   fill="url(#SVGID_1_)"
+   d="M12,7h72c3.866,0,7,3.134,7,7v71c0,3.866-3.134,7-7,7H12c-3.866,0-7-3.134-7-7V14    C5,10.134,8.134,7,12,7z"
+   id="path14" />
+	</g>
+</g>
+
+<g
+   id="g92">
+	
+		
+	<g
+   id="g96"
+   style="filter:url(#filter3237);fill:#ffffff">
+		<g
+   id="g98"
+   style="fill:#ffffff">
+			<path
+   stroke-miterlimit="10"
+   d="M69.063,74.334H58.117l-2.245-13.232H36.023     l-6.095,13.232h-9.263L46.89,19.601h12.149L69.063,74.334z M54.949,53.483l-4.29-24.299L39.392,53.483H54.949z"
+   id="path100"
+   stroke-width="0.5"
+   stroke="#BABABD"
+   fill="#FFFCD6"
+   style="fill:#ffffff" />
+		</g>
+	</g>
+</g>
+<path
+   style="fill:#1a1a1a"
+   d="m 21.568695,73.518356 c 0.09975,-0.259953 5.900128,-12.414294 12.889722,-27.009648 l 12.708353,-26.537004 5.766605,0 5.766603,0 1.146685,6.250804 c 0.630676,3.437942 2.852193,15.557556 4.936705,26.932476 l 3.790022,20.681672 -4.938833,0.08508 c -2.980192,0.05134 -5.012787,-0.03459 -5.125317,-0.216661 -0.102565,-0.165953 -0.653324,-3.156007 -1.223913,-6.644561 l -1.03743,-6.342825 -10.254456,0 -10.254455,0 -3.050914,6.636656 -3.050913,6.636656 -4.124917,0 c -3.577086,0 -4.100829,-0.06277 -3.943547,-0.472641 z M 55.316123,53.232154 C 55.228584,52.850161 54.206453,47.08582 53.04472,40.422508 51.882984,33.759197 50.858304,28.307106 50.767649,28.306752 50.633414,28.306229 44.38747,41.594414 39.777238,51.688746 l -1.022102,2.237942 8.360076,0 8.360077,0 -0.159166,-0.694534 0,0 z"
+   id="path3004"
+   inkscape:connector-curvature="0" /></svg>

--- a/lib/autokey/qtui/resources/icons/autokey-status-error.svg
+++ b/lib/autokey/qtui/resources/icons/autokey-status-error.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2408"
+   x="0px"
+   y="0px"
+   width="96px"
+   height="96px"
+   viewBox="0 0 96 96"
+   enable-background="new 0 0 96 96"
+   xml:space="preserve"
+   inkscape:version="0.48.2 r9819"
+   sodipodi:docname="autokey-status.svg"><metadata
+   id="metadata106"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs104"><filter
+     id="filter3237"
+     inkscape:label="Drop shadow"
+     width="1.5"
+     height="1.5"
+     x="-.25"
+     y="-.25"><feGaussianBlur
+       id="feGaussianBlur3239"
+       in="SourceAlpha"
+       stdDeviation="1"
+       result="blur" /><feColorMatrix
+       id="feColorMatrix3241"
+       result="bluralpha"
+       type="matrix"
+       values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.5 0 " /><feOffset
+       id="feOffset3243"
+       in="bluralpha"
+       dx="3"
+       dy="3"
+       result="offsetBlur" /><feMerge
+       id="feMerge3245"><feMergeNode
+         id="feMergeNode3247"
+         in="offsetBlur" /><feMergeNode
+         id="feMergeNode3249"
+         in="SourceGraphic" /></feMerge></filter></defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="899"
+   inkscape:window-height="721"
+   id="namedview102"
+   showgrid="false"
+   inkscape:zoom="3.2395833"
+   inkscape:cx="48"
+   inkscape:cy="48"
+   inkscape:window-x="311"
+   inkscape:window-y="24"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg2408" />
+<filter
+   id="filter3794"
+   x="-0.192"
+   width="1.3839999"
+   y="-0.192"
+   height="1.3839999"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3796"
+   stdDeviation="5.28" />
+</filter>
+<filter
+   id="filter3218"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3220"
+   stdDeviation="1.71" />
+</filter>
+<g
+   id="layer2"
+   display="none">
+	<g
+   id="rect3745"
+   display="inline"
+   opacity="0.9"
+   filter="url(#filter3218)"
+   enable-background="new    ">
+		
+			<linearGradient
+   id="SVGID_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="37.8677"
+   y1="-22.7129"
+   x2="37.8677"
+   y2="62.7856"
+   gradientTransform="matrix(1.0059 0 0 -0.9942 9.9104 69.4184)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop10" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop12" />
+		</linearGradient>
+		<path
+   fill="url(#SVGID_1_)"
+   d="M12,7h72c3.866,0,7,3.134,7,7v71c0,3.866-3.134,7-7,7H12c-3.866,0-7-3.134-7-7V14    C5,10.134,8.134,7,12,7z"
+   id="path14" />
+	</g>
+</g>
+
+<g
+   id="g92">
+	
+		
+	<g
+   id="g96"
+   style="filter:url(#filter3237);fill:#ffffff">
+		<g
+   id="g98"
+   style="fill:#ffffff">
+			<path
+   stroke-miterlimit="10"
+   d="M69.063,74.334H58.117l-2.245-13.232H36.023     l-6.095,13.232h-9.263L46.89,19.601h12.149L69.063,74.334z M54.949,53.483l-4.29-24.299L39.392,53.483H54.949z"
+   id="path100"
+   stroke-width="0.5"
+   stroke="#BABABD"
+   fill="#FFFCD6"
+   style="fill:#ffffff" />
+		</g>
+	</g>
+</g>
+<path
+   style="fill:#ff0000"
+   d="m 21.459407,73.821222 c 0.0033,-0.127331 5.767392,-12.246945 12.809055,-26.932476 l 12.803024,-26.700965 5.828561,-0.0837 5.828558,-0.0837 0.541486,3.01618 c 0.29782,1.658899 2.513361,13.781453 4.923424,26.93901 l 4.381934,23.92283 -4.939864,0.08508 c -2.980862,0.05134 -5.013815,-0.03458 -5.126345,-0.21666 -0.102565,-0.165954 -0.653324,-3.156008 -1.223913,-6.644562 l -1.03743,-6.342825 -10.259112,0 -10.259111,0 -3.048117,6.631798 -3.048117,6.6318 -4.090032,0.0049 c -2.249518,0.0027 -4.087318,-0.09932 -4.084001,-0.226653 z M 55.314842,53.13955 c -0.09102,-0.466881 -1.114288,-6.231104 -2.273928,-12.809384 -1.15964,-6.578281 -2.18975,-11.960917 -2.289131,-11.961415 -0.22842,-0.0011 -11.703552,24.760461 -11.703552,25.2545 0,0.271964 2.097144,0.365173 8.21605,0.365173 l 8.216048,0 -0.165487,-0.848874 0,0 z"
+   id="path3002"
+   inkscape:connector-curvature="0" /></svg>

--- a/lib/autokey/qtui/resources/icons/autokey-status.svg
+++ b/lib/autokey/qtui/resources/icons/autokey-status.svg
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2408"
+   x="0px"
+   y="0px"
+   width="96px"
+   height="96px"
+   viewBox="0 0 96 96"
+   enable-background="new 0 0 96 96"
+   xml:space="preserve"
+   inkscape:version="0.48.1 r9760"
+   sodipodi:docname="autokey.svg"><metadata
+   id="metadata106"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs104"><filter
+     id="filter3237"
+     inkscape:label="Drop shadow"
+     width="1.5"
+     height="1.5"
+     x="-.25"
+     y="-.25"><feGaussianBlur
+       id="feGaussianBlur3239"
+       in="SourceAlpha"
+       stdDeviation="1"
+       result="blur" /><feColorMatrix
+       id="feColorMatrix3241"
+       result="bluralpha"
+       type="matrix"
+       values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.5 0 " /><feOffset
+       id="feOffset3243"
+       in="bluralpha"
+       dx="3"
+       dy="3"
+       result="offsetBlur" /><feMerge
+       id="feMerge3245"><feMergeNode
+         id="feMergeNode3247"
+         in="offsetBlur" /><feMergeNode
+         id="feMergeNode3249"
+         in="SourceGraphic" /></feMerge></filter></defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="899"
+   inkscape:window-height="730"
+   id="namedview102"
+   showgrid="false"
+   inkscape:zoom="3.2395833"
+   inkscape:cx="48"
+   inkscape:cy="48"
+   inkscape:window-x="311"
+   inkscape:window-y="281"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="svg2408" />
+<filter
+   id="filter3794"
+   x="-0.192"
+   width="1.3839999"
+   y="-0.192"
+   height="1.3839999"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3796"
+   stdDeviation="5.28" />
+</filter>
+<filter
+   id="filter3218"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3220"
+   stdDeviation="1.71" />
+</filter>
+<g
+   id="layer2"
+   display="none">
+	<g
+   id="rect3745"
+   display="inline"
+   opacity="0.9"
+   filter="url(#filter3218)"
+   enable-background="new    ">
+		
+			<linearGradient
+   id="SVGID_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="37.8677"
+   y1="-22.7129"
+   x2="37.8677"
+   y2="62.7856"
+   gradientTransform="matrix(1.0059 0 0 -0.9942 9.9104 69.4184)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop10" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop12" />
+		</linearGradient>
+		<path
+   fill="url(#SVGID_1_)"
+   d="M12,7h72c3.866,0,7,3.134,7,7v71c0,3.866-3.134,7-7,7H12c-3.866,0-7-3.134-7-7V14    C5,10.134,8.134,7,12,7z"
+   id="path14" />
+	</g>
+</g>
+
+<g
+   id="g92">
+	
+		
+	<g
+   id="g96"
+   style="filter:url(#filter3237);fill:#ffffff">
+		<g
+   id="g98"
+   style="fill:#ffffff">
+			<path
+   stroke-miterlimit="10"
+   d="M69.063,74.334H58.117l-2.245-13.232H36.023     l-6.095,13.232h-9.263L46.89,19.601h12.149L69.063,74.334z M54.949,53.483l-4.29-24.299L39.392,53.483H54.949z"
+   id="path100"
+   stroke-width="0.5"
+   stroke="#BABABD"
+   fill="#FFFCD6"
+   style="fill:#ffffff" />
+		</g>
+	</g>
+</g>
+</svg>

--- a/lib/autokey/qtui/resources/icons/autokey.svg
+++ b/lib/autokey/qtui/resources/icons/autokey.svg
@@ -1,0 +1,430 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2408"
+   x="0px"
+   y="0px"
+   width="96px"
+   height="96px"
+   viewBox="0 0 96 96"
+   enable-background="new 0 0 96 96"
+   xml:space="preserve"
+   inkscape:version="0.48.1 r9760"
+   sodipodi:docname="akicon.svg"><metadata
+   id="metadata106"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs104"><filter
+     id="filter3237"
+     inkscape:label="Drop shadow"
+     width="1.5"
+     height="1.5"
+     x="-.25"
+     y="-.25"><feGaussianBlur
+       id="feGaussianBlur3239"
+       in="SourceAlpha"
+       stdDeviation="1"
+       result="blur" /><feColorMatrix
+       id="feColorMatrix3241"
+       result="bluralpha"
+       type="matrix"
+       values="1 0 0 0 0 0 1 0 0 0 0 0 1 0 0 0 0 0 0.5 0 " /><feOffset
+       id="feOffset3243"
+       in="bluralpha"
+       dx="3"
+       dy="3"
+       result="offsetBlur" /><feMerge
+       id="feMerge3245"><feMergeNode
+         id="feMergeNode3247"
+         in="offsetBlur" /><feMergeNode
+         id="feMergeNode3249"
+         in="SourceGraphic" /></feMerge></filter></defs><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="899"
+   inkscape:window-height="730"
+   id="namedview102"
+   showgrid="false"
+   inkscape:zoom="3.2395833"
+   inkscape:cx="48"
+   inkscape:cy="48"
+   inkscape:window-x="311"
+   inkscape:window-y="281"
+   inkscape:window-maximized="0"
+   inkscape:current-layer="g92" />
+<filter
+   id="filter3794"
+   x="-0.192"
+   width="1.3839999"
+   y="-0.192"
+   height="1.3839999"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3796"
+   stdDeviation="5.28" />
+</filter>
+<filter
+   id="filter3218"
+   color-interpolation-filters="sRGB">
+	<feGaussianBlur
+   id="feGaussianBlur3220"
+   stdDeviation="1.71" />
+</filter>
+<g
+   id="layer2"
+   display="none">
+	<g
+   id="rect3745"
+   display="inline"
+   opacity="0.9"
+   filter="url(#filter3218)"
+   enable-background="new    ">
+		
+			<linearGradient
+   id="SVGID_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="37.8677"
+   y1="-22.7129"
+   x2="37.8677"
+   y2="62.7856"
+   gradientTransform="matrix(1.0059 0 0 -0.9942 9.9104 69.4184)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop10" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop12" />
+		</linearGradient>
+		<path
+   fill="url(#SVGID_1_)"
+   d="M12,7h72c3.866,0,7,3.134,7,7v71c0,3.866-3.134,7-7,7H12c-3.866,0-7-3.134-7-7V14    C5,10.134,8.134,7,12,7z"
+   id="path14" />
+	</g>
+</g>
+<g
+   id="g16">
+	<g
+   id="layer5">
+		
+			<linearGradient
+   id="path3786_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="33.8071"
+   y1="806.4756"
+   x2="33.8071"
+   y2="722.3687"
+   gradientTransform="matrix(1.0238 0 0 1.0119 13.3877 -724.2102)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop20" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop22" />
+		</linearGradient>
+		<path
+   id="path3786"
+   opacity="0.08"
+   fill="url(#path3786_1_)"
+   enable-background="new    "
+   d="M12,95.031    c-5.511,0-10.031-4.52-10.031-10.031V14C1.969,8.489,6.489,3.969,12,3.969h72c5.512,0,10.031,4.52,10.031,10.031v71    c0,5.512-4.52,10.031-10.031,10.031H12z" />
+		
+			<linearGradient
+   id="path3778_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="33.8066"
+   y1="806.4756"
+   x2="33.8066"
+   y2="722.3687"
+   gradientTransform="matrix(1.0238 0 0 1.0119 13.3877 -724.2102)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop26" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop28" />
+		</linearGradient>
+		<path
+   id="path3778"
+   opacity="0.1"
+   fill="url(#path3778_1_)"
+   enable-background="new    "
+   d="M12,94.031    c-4.972,0-9.031-4.06-9.031-9.031V14c0-4.972,4.06-9.031,9.031-9.031h72c4.972,0,9.031,4.06,9.031,9.031v71    c0,4.972-4.06,9.031-9.031,9.031H12z" />
+		
+			<linearGradient
+   id="path3770_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="33.8071"
+   y1="806.4766"
+   x2="33.8071"
+   y2="722.3696"
+   gradientTransform="matrix(1.0238 0 0 1.0119 13.3877 -724.2102)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop32" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop34" />
+		</linearGradient>
+		<path
+   id="path3770"
+   opacity="0.2"
+   fill="url(#path3770_1_)"
+   enable-background="new    "
+   d="M12,93c-4.409,0-8-3.591-8-8V14    c0-4.409,3.591-8,8-8h72c4.409,0,8,3.591,8,8v71c0,4.409-3.591,8-8,8H12z" />
+		
+			<linearGradient
+   id="rect3723_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="33.8071"
+   y1="806.4766"
+   x2="33.8071"
+   y2="722.3696"
+   gradientTransform="matrix(1.0238 0 0 1.0119 13.3877 -724.2102)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop38" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop40" />
+		</linearGradient>
+		<path
+   id="rect3723"
+   opacity="0.3"
+   fill="url(#rect3723_1_)"
+   enable-background="new    "
+   d="M12,92h72c3.866,0,7-3.134,7-7V14    c0-3.866-3.134-7-7-7H12c-3.866,0-7,3.134-7,7v71C5,88.866,8.134,92,12,92z" />
+		
+			<linearGradient
+   id="rect3716_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="39.6001"
+   y1="810.8584"
+   x2="39.6001"
+   y2="726.7515"
+   gradientTransform="matrix(1 0 0 1 8.3999 -719.9902)">
+			<stop
+   offset="0"
+   style="stop-color:#000000"
+   id="stop44" />
+			<stop
+   offset="1"
+   style="stop-color:#000000;stop-opacity:0.5882"
+   id="stop46" />
+		</linearGradient>
+		<path
+   id="rect3716"
+   opacity="0.45"
+   fill="url(#rect3716_1_)"
+   enable-background="new    "
+   d="M12,91h72c3.313,0,6-2.687,6-6V13    c0-3.313-2.687-6-6-6H12c-3.313,0-6,2.687-6,6v72C6,88.313,8.687,91,12,91z" />
+	</g>
+	<g
+   id="layer1">
+		
+			<linearGradient
+   id="rect2419_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="39.6001"
+   y1="-17.9902"
+   x2="39.6001"
+   y2="66.0103"
+   gradientTransform="matrix(1 0 0 -1 8.3999 72.0098)">
+			<stop
+   offset="0"
+   style="stop-color:#1D5282"
+   id="stop51" />
+			<stop
+   offset="1"
+   style="stop-color:#568EC2"
+   id="stop53" />
+		</linearGradient>
+		<path
+   id="rect2419"
+   fill="url(#rect2419_1_)"
+   d="M12,6h72c3.313,0,6,2.687,6,6v72c0,3.313-2.687,6-6,6H12c-3.313,0-6-2.687-6-6V12    C6,8.687,8.687,6,12,6z" />
+		<path
+   id="rect3312"
+   inkscape:connector-curvature="0"
+   opacity="0.7"
+   fill="#FFFFFF"
+   enable-background="new    "
+   d="M12,6    c-3.324,0-6,2.676-6,6v2v68v2c0,3.324,2.676,6,6,6h2h68h2c3.324,0,6-2.676,6-6v-2V14v-2c0-3.324-2.676-6-6-6h-2H14H12z M16,12h64    c2.216,0,4,1.784,4,4v64c0,2.216-1.784,4-4,4H16c-2.216,0-4-1.784-4-4V16C12,13.784,13.784,12,16,12z" />
+		
+			<linearGradient
+   id="rect3728_1_"
+   gradientUnits="userSpaceOnUse"
+   x1="139.5996"
+   y1="66.0098"
+   x2="139.5996"
+   y2="8.4032"
+   gradientTransform="matrix(1 0 0 -1 -91.6001 72.0098)">
+			<stop
+   offset="0"
+   style="stop-color:#FFFFFF"
+   id="stop58" />
+			<stop
+   offset="1"
+   style="stop-color:#FFFFFF;stop-opacity:0"
+   id="stop60" />
+		</linearGradient>
+		<path
+   id="rect3728"
+   inkscape:connector-curvature="0"
+   opacity="0.5"
+   fill="url(#rect3728_1_)"
+   enable-background="new    "
+   d="    M12,6c-3.324,0-6,2.676-6,6v72c0,2.678,1.744,4.882,4.156,5.656C8.296,88.928,7,87.13,7,85V13c0-2.782,2.218-5,5-5h72    c2.781,0,5,2.218,5,5v72c0,2.13-1.296,3.928-3.156,4.656C88.256,88.882,90,86.678,90,84V12c0-3.324-2.676-6-6-6H12z" />
+		
+			<radialGradient
+   id="path3615_1_"
+   cx="5.7402"
+   cy="-19.6929"
+   r="41.9998"
+   gradientTransform="matrix(1.1573 0 0 -0.9959 41.3567 70.3879)"
+   gradientUnits="userSpaceOnUse">
+			<stop
+   offset="0"
+   style="stop-color:#FFFFFF"
+   id="stop64" />
+			<stop
+   offset="1"
+   style="stop-color:#FFFFFF;stop-opacity:0"
+   id="stop66" />
+		</radialGradient>
+		<path
+   id="path3615"
+   inkscape:connector-curvature="0"
+   opacity="0.4"
+   fill="url(#path3615_1_)"
+   enable-background="new    "
+   d="    M12,90c-3.324,0-6-2.676-6-6v-2V14v-2c0-0.335,0.042-0.651,0.094-0.969c0.049-0.295,0.097-0.597,0.188-0.875    c0.01-0.03,0.021-0.063,0.031-0.094C6.411,9.775,6.547,9.515,6.688,9.25c0.145-0.273,0.315-0.536,0.5-0.781    s0.374-0.474,0.594-0.688c0.44-0.428,0.943-0.814,1.5-1.094c0.278-0.14,0.573-0.247,0.875-0.344C9.9,6.444,9.669,6.58,9.438,6.719    c-0.007,0.004-0.024-0.004-0.031,0c-0.032,0.02-0.063,0.042-0.094,0.063c-0.121,0.077-0.231,0.164-0.344,0.25    c-0.106,0.081-0.213,0.161-0.313,0.25c-0.178,0.162-0.348,0.345-0.5,0.531c-0.107,0.13-0.218,0.265-0.313,0.406    C7.819,8.257,7.805,8.305,7.781,8.344c-0.065,0.103-0.13,0.205-0.188,0.313C7.493,8.851,7.388,9.072,7.313,9.281    C7.305,9.303,7.289,9.322,7.281,9.344C7.25,9.436,7.246,9.531,7.219,9.625c-0.03,0.106-0.07,0.203-0.094,0.313    C7.052,10.279,7,10.636,7,11v2v68v2c0,2.781,2.218,5,5,5h2h68h2c2.781,0,5-2.219,5-5v-2V13v-2c0-0.364-0.053-0.721-0.125-1.063    c-0.044-0.207-0.088-0.397-0.156-0.594c-0.008-0.022-0.023-0.041-0.031-0.063c-0.063-0.174-0.139-0.367-0.219-0.531    c-0.041-0.083-0.079-0.17-0.125-0.25c-0.055-0.097-0.127-0.188-0.188-0.281c-0.094-0.141-0.205-0.276-0.313-0.406    c-0.143-0.174-0.303-0.347-0.469-0.5c-0.012-0.01-0.02-0.021-0.031-0.031c-0.139-0.125-0.285-0.234-0.438-0.344    c-0.103-0.073-0.204-0.153-0.313-0.219c-0.008-0.004-0.023,0.004-0.031,0C86.33,6.58,86.1,6.444,85.844,6.344    c0.302,0.097,0.597,0.204,0.875,0.344c0.557,0.279,1.061,0.666,1.5,1.094c0.221,0.214,0.409,0.442,0.594,0.688    s0.355,0.508,0.5,0.781c0.141,0.265,0.276,0.525,0.375,0.813c0.01,0.031,0.021,0.063,0.031,0.094    c0.09,0.278,0.139,0.58,0.188,0.875C89.959,11.349,90,11.665,90,12v2v68v2c0,3.324-2.676,6-6,6H12z" />
+		<g
+   id="g3716"
+   transform="translate(100,0)">
+			<path
+   id="path3703"
+   inkscape:connector-curvature="0"
+   opacity="0.05"
+   fill="#1A3854"
+   enable-background="new    "
+   d="M-84,12     c-2.216,0-4,1.784-4,4v64c0,2.216,1.784,4,4,4h64c2.216,0,4-1.784,4-4V16c0-2.216-1.784-4-4-4H-84z M-84,15.031h64     c0.588,0,0.969,0.381,0.969,0.969v64c0,0.588-0.381,0.969-0.969,0.969h-64c-0.588,0-0.969-0.381-0.969-0.969V16     C-84.969,15.412-84.588,15.031-84,15.031z" />
+			<path
+   id="path3662"
+   inkscape:connector-curvature="0"
+   opacity="0.1"
+   fill="#1A3854"
+   enable-background="new    "
+   d="M-84,12     c-2.216,0-4,1.784-4,4v64c0,2.216,1.784,4,4,4h64c2.216,0,4-1.784,4-4V16c0-2.216-1.784-4-4-4H-84z M-84,13.938h64     c1.172,0,2.063,0.89,2.063,2.063v64c0,1.172-0.891,2.063-2.063,2.063h-64c-1.172,0-2.063-0.891-2.063-2.063V16     C-86.063,14.828-85.172,13.938-84,13.938z" />
+			<path
+   id="path3636"
+   inkscape:connector-curvature="0"
+   opacity="0.22"
+   fill="#1A3854"
+   enable-background="new    "
+   d="M-84,12     c-2.216,0-4,1.784-4,4v64c0,2.216,1.784,4,4,4h64c2.216,0,4-1.784,4-4V16c0-2.216-1.784-4-4-4H-84z M-84,13.031h64     c1.665,0,2.969,1.304,2.969,2.969v64c0,1.665-1.304,2.969-2.969,2.969h-64c-1.665,0-2.969-1.304-2.969-2.969V16     C-86.969,14.335-85.665,13.031-84,13.031z" />
+		</g>
+	</g>
+	<g
+   id="layer3">
+		<g
+   id="g74">
+			<defs
+   id="defs76">
+				<path
+   id="SVGID_2_"
+   d="M12,6h72c3.313,0,6,2.687,6,6v72c0,3.313-2.687,6-6,6H12c-3.313,0-6-2.687-6-6V12C6,8.687,8.687,6,12,6z" />
+			</defs>
+			<clipPath
+   id="SVGID_3_">
+				<use
+   xlink:href="#SVGID_2_"
+   overflow="visible"
+   id="use80" />
+			</clipPath>
+			<g
+   id="rect3171"
+   opacity="0.1"
+   clip-path="url(#SVGID_3_)"
+   filter="url(#filter3794)"
+   enable-background="new    ">
+				
+					<linearGradient
+   id="SVGID_4_"
+   gradientUnits="userSpaceOnUse"
+   x1="39.6001"
+   y1="51.7891"
+   x2="39.6001"
+   y2="-66.6504"
+   gradientTransform="matrix(1 0 0 -1 8.3999 72.0098)">
+					<stop
+   offset="0"
+   style="stop-color:#FFFFFF"
+   id="stop84" />
+					<stop
+   offset="1"
+   style="stop-color:#FFFFFF;stop-opacity:0"
+   id="stop86" />
+				</linearGradient>
+				<path
+   fill="url(#SVGID_4_)"
+   d="M27,15h42c6.627,0,12,5.373,12,12v42c0,6.627-5.373,12-12,12H27c-6.627,0-12-5.373-12-12V27      C15,20.373,20.373,15,27,15z"
+   id="path88" />
+				<path
+   fill="none"
+   stroke="#FFFFFF"
+   stroke-width="0.5"
+   stroke-linecap="round"
+   d="M27,15h42c6.627,0,12,5.373,12,12v42      c0,6.627-5.373,12-12,12H27c-6.627,0-12-5.373-12-12V27C15,20.373,20.373,15,27,15z"
+   id="path90" />
+			</g>
+		</g>
+	</g>
+</g>
+<g
+   id="g92">
+	
+		
+	<g
+   id="g96"
+   style="filter:url(#filter3237);fill:#ffffff">
+		<g
+   id="g98"
+   style="fill:#ffffff">
+			<path
+   stroke-miterlimit="10"
+   d="M69.063,74.334H58.117l-2.245-13.232H36.023     l-6.095,13.232h-9.263L46.89,19.601h12.149L69.063,74.334z M54.949,53.483l-4.29-24.299L39.392,53.483H54.949z"
+   id="path100"
+   stroke-width="0.5"
+   stroke="#BABABD"
+   fill="#FFFCD6"
+   style="fill:#ffffff" />
+		</g>
+	</g>
+</g>
+</svg>


### PR DESCRIPTION
Related to #87

Add Wayland support to AutoKey.

* Add Wayland support in `lib/autokey/gtkapp.py` and `lib/autokey/qtapp.py` by using `pywayland` and `libinput`.
* Update `lib/autokey/iomediator/keygrabber.py` and `lib/autokey/iomediator/windowgrabber.py` to handle keyboard and mouse events using Wayland-specific methods.
* Update `README.rst` to remove the statement that AutoKey is an X11 application and will not function correctly with Wayland.
* Update `.github/ISSUE_TEMPLATE/bug.yml` to remove the dropdown asking users if they use Xorg or Wayland.
* Add new icons for Wayland support in `lib/autokey/qtui/resources/icons/`.

