### PR TITLE
Satisfy Python 3.12.7 compatibility in issue #964 by adding the pyasyncore dependency.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Important misc changes
 - Bump action versions in python-test.yml to satisfy part of issue #963.
 - Bump Python version in build.yml to satisfy part of issue #964.
 - Bump Python versions in python-test.yml to satisfy part of issue #964.
+- Add `pyasyncore` to `[testenv]` section of the `setup.cfg` file to satisfy issue #964.
 
 Other
 +++++

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ envlist = test
 
 [testenv]
 deps =
+    pyasyncore
     pytest
     pytest-cov
     pyhamcrest>=1.8.1


### PR DESCRIPTION
Use code from the patch [provided by @dlk3](https://github.com/autokey/autokey/issues/946#issuecomment-2479559325) to replace the deprecated `asyncore` module with the `pyasyncore` module as a dependency in the `[testenv]` section of the `setup.cfg` file to resolve tox errors and make AutoKey compatible with Python 3.12.7.