### PR TITLE
Revert "Satisfy Python 3.12.7 compatibility in issue #964 by adding the pyasyncore dependency."

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,6 @@ Important misc changes
 - Bump action versions in python-test.yml to satisfy part of issue #963.
 - Bump Python version in build.yml to satisfy part of issue #964.
 - Bump Python versions in python-test.yml to satisfy part of issue #964.
-- Add `pyasyncore` to `[testenv]` section of the `setup.cfg` file to satisfy issue #964.
 
 Other
 +++++

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ envlist = test
 
 [testenv]
 deps =
-    pyasyncore
     pytest
     pytest-cov
     pyhamcrest>=1.8.1


### PR DESCRIPTION
Reverts autokey/autokey#976.