### PR TITLE
Add `pyasyncore` dependency to satisfy issue #946 and #964 for use in Python 3.12.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Important misc changes
 - Bump action versions in python-test.yml to satisfy part of issue #963.
 - Bump Python version in build.yml to satisfy part of issue #964.
 - Bump Python versions in python-test.yml to satisfy part of issue #964.
+- Add `pyasyncore` dependency to `setup.py` for use in Python 3.12 to satisfy issues #946 and #964.
 
 Other
 +++++

--- a/setup.py
+++ b/setup.py
@@ -176,6 +176,7 @@ setup(
     # Some are not included here because they should be installed
     # through the system package manager, not pip.
     install_requires=[
+        'pyasyncore',
         'pyinotify',
         'python-xlib',
         'packaging',


### PR DESCRIPTION
Resolve tox errors and make AutoKey compatible with Python 3.12. Original credit for this fix goes to @dlk3 in issue #946.
