### PR TITLE
Bump Python versions in `setup.cfg` and `setup.py`  -- fixes #969 and fixes #970

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Important misc changes
 - Bump action versions in python-test.yml to satisfy part of issue #963.
 - Bump Python version in build.yml to satisfy part of issue #964.
 - Bump Python versions in python-test.yml to satisfy part of issue #964.
+- Bump Python versions in setup.cfg to satisfy issue #969.
+- Bump Python versions in setup.py to satisfy issue #970.
 - Add `pyasyncore` dependency to `setup.py` for use in Python 3.12 to satisfy issues #946 and #964.
 
 Other

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ addopts =
 
 
 [tox:tox]
-; envlist = py36,py39
+; envlist = py39,py311
 ; Only run test environment by default, so just running `tox` is fast
 ; and doesn't include the overhead of coverage or any other build
 ; pathways.

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ except ImportError:
 else:
     import setuptools.command.build_py
 
-if sys.version_info < (3, 7, 0):
-    print("Autokey requires Python 3.7 or later. You are using " + ".".join(map(str, sys.version_info[:3])))
+if sys.version_info < (3, 9, 20):
+    print("Autokey requires Python 3.9 or later. You are using " + ".".join(map(str, sys.version_info[:3])))
     sys.exit(1)
 
 
@@ -129,7 +129,7 @@ setup(
     url='https://github.com/autokey/autokey',
     cmdclass={'build_py': BuildWithQtResources},
     license='GPLv3',
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     # This requires autokey submodules (subdirectories) to contain their own `__init__.py` file (i.e.
     # they advertise themselves as modules).
     # find_namespace_packages might be a better alternative that doesn't
@@ -189,7 +189,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='automation hotkey expansion expander phrase',
 )


### PR DESCRIPTION
This is not yet the bump to Python **Python 3.12.7**, but is finishing the bump to **Python 3.11.10** to synchronize all the workflow-related files.