### PR TITLE
Bump Python to all GitHub-supported versions -- fixes #986

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11.10]
+        python-version: [3.12.3]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11.10]
+        python-version: [3.12.3]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.11.10]
+        python-version: [3.12.3]
     needs: [build_pypi_wheel, build_deb]
     steps:
     - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
         ref: ${{ github.ref }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 10
-        check-name: 'pytest (3.10.1)'
+        check-name: 'pytest (3.12.3)'
 
     - name: Download built dist as artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: [3.9, 3.10, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: [3.9, 3.10, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.9", "3.11"]
+        python-version: [3.9, 3.10, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Important misc changes
 - Bump Python versions in python-test.yml to satisfy part of issue #964.
 - Bump Python versions in setup.cfg to satisfy issue #969.
 - Bump Python versions in setup.py to satisfy issue #970.
+- Bump Python versions to all GitHub-supported versions to satisfy issue #986.
 - Add `pyasyncore` dependency to `setup.py` for use in Python 3.12 to satisfy issues #946 and #964.
 
 Other

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ addopts =
 
 
 [tox:tox]
-; envlist = py39,py311
+; envlist = py39,py310,py311,py312
 ; Only run test environment by default, so just running `tox` is fast
 ; and doesn't include the overhead of coverage or any other build
 ; pathways.


### PR DESCRIPTION
This is how the versions were chosen:
* `build.yml` uses the Python version shipped in the most-recent **Ubuntu** release.
* `python-test.yml` uses the Python versions supported by **GitHub**.
* `setup.cfg` uses the Python versions supported by **GitHub**
