### PR TITLE
Bump versions in workflow and other files on develop.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,16 +18,16 @@ jobs:
       matrix:
         python-version: [3.10]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -53,7 +53,7 @@ jobs:
         mv ../*.deb debs
 
     - name: Upload built debs as artifacts
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v4
       with:
         name: debs
         path: debs
@@ -66,14 +66,14 @@ jobs:
       matrix:
         python-version: [3.10]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache pip
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         # This path is specific to Ubuntu
         path: ~/.cache/pip
@@ -99,7 +99,7 @@ jobs:
         --outdir dist/
 
     - name: Upload built dist as artifact
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/
@@ -113,7 +113,7 @@ jobs:
         python-version: [3.10]
     needs: [build_pypi_wheel, build_deb]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         # Fetch all history so that we get tags.
         fetch-depth: 0
@@ -128,12 +128,12 @@ jobs:
         check-name: 'pytest (3.10)'
 
     - name: Download built dist as artifact
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist/
     - name: Download built debs as artifacts
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v4
       with:
         name: debs
         path: ../debs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: [3.12.3]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: [3.12.3]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -110,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.10]
+        python-version: [3.12.3]
     needs: [build_pypi_wheel, build_deb]
     steps:
     - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
         ref: ${{ github.ref }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         wait-interval: 10
-        check-name: 'pytest (3.10)'
+        check-name: 'pytest (3.12.3)'
 
     - name: Download built dist as artifact
       uses: actions/download-artifact@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Publish Old Autokey Epydoc documentation
+on: [workflow_dispatch]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/scripting
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+          

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -24,14 +24,14 @@ jobs:
         python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -86,16 +86,16 @@ jobs:
         python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -117,7 +117,7 @@ jobs:
         run: tox -e clean,coverage,report
 
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: junit/test-results-${{ matrix.python-version }}.xml
@@ -128,7 +128,7 @@ jobs:
         run: tar -cvzf test_coverage_report-${{ matrix.python-version }}.tar.gz test_coverage_report_html/
 
       - name: Upload test coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test_coverage_report-${{ matrix.python-version }}.tar.gz
           path: test_coverage_report-${{ matrix.python-version }}.tar.gz
@@ -145,9 +145,9 @@ jobs:
         python-version: ["3.7", "3.10"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -142,7 +142,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -31,6 +31,11 @@ Important misc changes
 - Bump the AutoKey version to 0.96.1 in the **autokey.spec** file to satisfy part of issue #227.
 - Fix erroneous `window.close` in place of `window.resize_move` in documentation
 - Adds GNOME Window Extension for interacting with Windows on x11/wayland
+- Copy bumped versions in ``build.yml`` to **develop** -- issue #993.
+- Copy ``pages.yml`` to **develop** -- issue #993.
+- Copy bumped versions in ``python-test.yml`` to **develop** -- issue #993.
+- Copy bumped versions in ``setup.cfg`` to **develop** -- issue #993.
+- Copy bumped versions and **pyasyncore** fix in ``setup.py`` to **develop** -- issue #993.
 
 
 Features

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ addopts =
 
 
 [tox:tox]
-; envlist = py37,py310
+; envlist = py39,py310,py311,py312
 ; Only run test environment by default, so just running `tox` is fast
 ; and doesn't include the overhead of coverage or any other build
 ; pathways.

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,8 @@ except ImportError:
 else:
     import setuptools.command.build_py
 
-if sys.version_info < (3, 7, 15):
-    print("Autokey requires Python 3.7.15 or later. You are using " + ".".join(map(str, sys.version_info[:3])))
+if sys.version_info < (3, 9, 20):
+    print("Autokey requires Python 3.9 or later. You are using " + ".".join(map(str, sys.version_info[:3])))
     sys.exit(1)
 
 
@@ -137,7 +137,7 @@ setup(
     # If using this, would have to also set common.VERSION from this so that
     # the autokey 'about' menu shows the correct version.
     # use_scm_version=True,
-    python_requires=">=3.7.15",
+    python_requires=">=3.9",
     # This requires autokey submodules (subdirectories) to contain their own `__init__.py` file (i.e.
     # they advertise themselves as modules).
     # find_namespace_packages might be a better alternative that doesn't
@@ -210,7 +210,7 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.9',
     ],
     keywords='automation hotkey expansion expander phrase macros keyboard auto key autokey ak shortcuts bind autohotkey mouse customization',
 )

--- a/setup.py
+++ b/setup.py
@@ -188,6 +188,7 @@ setup(
     # Some are not included here because they should be installed
     # through the system package manager, not pip.
     install_requires=[
+        'pyasyncore',
         'pyinotify',
         'python-xlib',
         'packaging',


### PR DESCRIPTION
* Copy bumped action and Python versions from workflow and other files on **master** to workflow files on **develop**.
* Copy `pages.yml` workflow file from **master** to **develop**.
* Copy **pyasyncore** fix from `setup.py` on **master** to `setup.py` on **develop** as part of this update (from the fix for [issue #946](https://github.com/autokey/autokey/issues/946) and [issue #964](https://github.com/autokey/autokey/issues/964) that had already been done on **master**).
