### PR TITLE
Make on-disk logfile content match console message output

### DIFF
--- a/lib/autokey/logger.py
+++ b/lib/autokey/logger.py
@@ -44,6 +44,7 @@ def configure_root_logger(args: Namespace):
         backupCount=MAX_LOG_COUNT
     )
     file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(logging.Formatter(LOG_FORMAT))
 
     stdout_stream_handler = logging.StreamHandler(sys.stdout)
     logging_level = logging.INFO
@@ -51,7 +52,8 @@ def configure_root_logger(args: Namespace):
         logging_level = logging.DEBUG
     if args.mouse_logging:
         logging_level = 9
-    
+
+    file_handler.setLevel(logging_level)
     stdout_stream_handler.setLevel(logging_level)
     stdout_stream_handler.setFormatter(logging.Formatter(LOG_FORMAT))
 


### PR DESCRIPTION
Adjust the format of the messages recorded in the $HOME/.local/share/autokey/autokey.log disk file so that they match the format of the messages output to the console.  (Adds time/date stamp and affected module name to the messages in the on-disk log file.)

Make it so that the disk file honors the --verbose and --mouse debugging options and contains the exact same messages as these options output to the console.

May resolve issue #709 